### PR TITLE
feat: add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,189 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  # Build and test before releasing
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linting
+        run: npm run lint
+
+      - name: Run type checking
+        run: npm run typecheck
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Build production bundle
+        run: npm run package
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
+      - name: Package extension
+        run: vsce package --no-dependencies
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-package
+          path: "*.vsix"
+          retention-days: 30
+
+  # Generate changelog from conventional commits
+  changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      changelog: ${{ steps.changelog.outputs.changelog }}
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          excludeTypes: "chore,docs,style"
+          includeInvalidCommits: true
+
+  # Create GitHub Release with VSIX artifact
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build, changelog]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vsix-package
+
+      - name: List artifacts
+        run: ls -la *.vsix
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "*.vsix"
+          body: |
+            ## What's Changed
+
+            ${{ needs.changelog.outputs.changelog }}
+
+            ## Installation
+
+            ### From VSIX file
+            1. Download the `.vsix` file from this release
+            2. In VS Code, open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
+            3. Run "Extensions: Install from VSIX..."
+            4. Select the downloaded file
+
+            ### From Open VSX Registry
+            Search for "F5 Distributed Cloud Tools" in VS Code extensions
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+
+  # Publish to Open VSX Registry
+  publish-openvsx:
+    name: Publish to Open VSX
+    runs-on: ubuntu-latest
+    needs: [build, release]
+    if: ${{ !contains(github.ref_name, '-') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vsix-package
+
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: "*.vsix"
+          skipDuplicate: true
+
+  # Publish to VS Code Marketplace (when token is configured)
+  publish-marketplace:
+    name: Publish to VS Marketplace
+    runs-on: ubuntu-latest
+    needs: [build, release]
+    if: ${{ !contains(github.ref_name, '-') && vars.MARKETPLACE_ENABLED == 'true' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vsix-package
+
+      - name: Publish to VS Code Marketplace
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: "*.vsix"
+          skipDuplicate: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,5 +50,6 @@ and this project adheres to
 - P12 certificate password encrypted in secure storage
 
 [Unreleased]:
-  https://github.com/f5networks/vscode-f5xc-tools/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/f5networks/vscode-f5xc-tools/releases/tag/v0.1.0
+  https://github.com/robinmordasiewicz/vscode-f5xc-tools/compare/v0.1.0...HEAD
+[0.1.0]:
+  https://github.com/robinmordasiewicz/vscode-f5xc-tools/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/f5networks/vscode-f5xc-tools"
+    "url": "https://github.com/robinmordasiewicz/vscode-f5xc-tools"
   },
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Summary

Adds a complete automated release workflow for publishing the VSCode extension.

### Features

- **Tag-based triggering**: Workflow runs on version tags (`v0.1.0`, `v1.2.3`, etc.)
- **Build & Test**: Full validation before any release
- **Changelog generation**: Automatic changelog from conventional commits
- **GitHub Releases**: Creates release with VSIX artifact attached
- **Open VSX Registry**: Publishes to Open VSX (token configured)
- **VS Marketplace**: Ready for publishing when token is configured

### Workflow Jobs

| Job | Purpose |
|-----|---------|
| `build` | Lint, typecheck, test, and package extension |
| `changelog` | Generate changelog from commits |
| `release` | Create GitHub Release with VSIX |
| `publish-openvsx` | Publish to Open VSX Registry |
| `publish-marketplace` | Publish to VS Marketplace (when enabled) |

### Secrets Configured

- [x] `OPEN_VSX_TOKEN` - Added

### To Enable VS Marketplace Publishing

1. Create Azure DevOps PAT with Marketplace permissions
2. Add `VS_MARKETPLACE_TOKEN` secret
3. Create repository variable `MARKETPLACE_ENABLED` = `true`

### Additional Changes

- Fixed repository URLs in `package.json` and `CHANGELOG.md`

## Test Plan

- [ ] CI workflow passes
- [ ] Create a test tag `v0.1.0` to trigger release workflow
- [ ] Verify GitHub Release is created with VSIX
- [ ] Verify Open VSX publishing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)