### PR TITLE
feat: group namespaces into built-in and custom categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.13] - 2024-12-04
+
+### Added
+
+- Filter Resources command (`F5 XC: Filter Resources`) - filters the tree view
+  to show only matching resources
+- Filter icon in Resources view title bar for quick access
+- Clear Filter command to restore normal tree view
+- Tree view title shows active filter text
+- Fuzzy matching for filter (e.g., "azure lb" matches "my-azure-http-lb")
+
+### Improved
+
+- Find Resource and Filter Resources both load in parallel for faster results
+
+## [0.1.12] - 2024-12-04
+
+### Added
+
+- Find Resource command (`F5 XC: Find Resource`) - searchable list of all
+  resources across namespaces
+- Search icon in Resources view title bar for quick access
+- Keyboard shortcut `Cmd+Shift+F` (when focused on F5 XC explorer) to open
+  search
+
+## [0.1.11] - 2024-12-04
+
+### Fixed
+
+- Fixed handling of different F5 XC API response structures when opening
+  resources for editing
+- API responses wrapped in `object` or `get_spec` are now properly unwrapped
+
 ## [0.1.10] - 2024-12-04
 
 ### Fixed
@@ -125,7 +158,13 @@ and this project adheres to
 - P12 certificate password encrypted in secure storage
 
 [Unreleased]:
-  https://github.com/robinmordasiewicz/vscode-f5xc-tools/compare/v0.1.10...HEAD
+  https://github.com/robinmordasiewicz/vscode-f5xc-tools/compare/v0.1.13...HEAD
+[0.1.13]:
+  https://github.com/robinmordasiewicz/vscode-f5xc-tools/compare/v0.1.12...v0.1.13
+[0.1.12]:
+  https://github.com/robinmordasiewicz/vscode-f5xc-tools/compare/v0.1.11...v0.1.12
+[0.1.11]:
+  https://github.com/robinmordasiewicz/vscode-f5xc-tools/compare/v0.1.10...v0.1.11
 [0.1.10]:
   https://github.com/robinmordasiewicz/vscode-f5xc-tools/compare/v0.1.9...v0.1.10
 [0.1.9]:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-f5xc-tools",
   "displayName": "F5 Distributed Cloud Tools",
   "description": "Manage F5 Distributed Cloud resources directly from VS Code",
-  "version": "0.1.10",
+  "version": "0.1.13",
   "publisher": "robinmordasiewicz",
   "license": "Apache-2.0",
   "repository": {
@@ -219,7 +219,7 @@
         {
           "command": "f5xc.refresh",
           "when": "view == f5xc.explorer",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "f5xc.addProfile",

--- a/src/tree/treeTypes.ts
+++ b/src/tree/treeTypes.ts
@@ -16,6 +16,7 @@ export interface F5XCTreeItem {
  * Context value prefixes for tree items
  */
 export const TreeItemContext = {
+  NAMESPACE_GROUP: 'namespaceGroup',
   NAMESPACE: 'namespace',
   CATEGORY: 'category',
   RESOURCE_TYPE: 'resourceType',


### PR DESCRIPTION
## Summary
- Add namespace grouping in Resources tree view with Built-in and Custom categories
- Built-in namespaces (system, shared, default) appear at top in specified order
- Custom namespaces grouped separately and sorted alphabetically
- Enhanced resource tooltip with namespace and category info

## Test plan
- [ ] Verify Built-in Namespaces group shows system, shared, default in order
- [ ] Verify Custom Namespaces group shows all other namespaces alphabetically
- [ ] Verify both groups expand by default
- [ ] Verify tooltip shows namespace count for each group

🤖 Generated with [Claude Code](https://claude.ai/code)