### PR TITLE
feat: enable vscode marketplace publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,12 +148,12 @@ jobs:
           extensionFile: ${{ steps.vsix.outputs.filename }}
           skipDuplicate: true
 
-  # Publish to VS Code Marketplace (when token is configured)
+  # Publish to VS Code Marketplace
   publish-marketplace:
     name: Publish to VS Marketplace
     runs-on: ubuntu-latest
     needs: [build, release]
-    if: ${{ !contains(github.ref_name, '-') && vars.MARKETPLACE_ENABLED == 'true' }}
+    if: ${{ !contains(github.ref_name, '-') }}
 
     steps:
       - name: Checkout repository

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "F5 Distributed Cloud Tools",
   "description": "Manage F5 Distributed Cloud resources directly from VS Code",
   "version": "0.1.13",
-  "publisher": "robinmordasiewicz",
+  "publisher": "vscode-f5xc-tools",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Update publisher to `vscode-f5xc-tools` to match marketplace account
- Simplify release workflow to always publish to VS Marketplace
- Remove `MARKETPLACE_ENABLED` variable check (relies on secret presence)

## Test plan
- [x] VS_MARKETPLACE_TOKEN secret created in repository
- [ ] Verify extension publishes on next release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)