### PR TITLE
fix: remove invalid 'Cloud' category from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "vscode": "^1.85.0"
   },
   "categories": [
-    "Other",
-    "Cloud"
+    "Other"
   ],
   "keywords": [
     "f5",


### PR DESCRIPTION
## Summary
- Remove invalid 'Cloud' category from VS Code extension manifest
- The VS Code Marketplace only accepts specific categories, and 'Cloud' is not valid
- This was causing the v0.1.13 release publish to fail

## Root Cause
The publish-marketplace job failed with:
```
The category 'Cloud' is not available in language 'en-us'
```

## Test Plan
- [ ] Create new release tag after merge to trigger workflow
- [ ] Verify VS Code Marketplace publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)