### PR TITLE
fix: update publisher to robinmordasiewicz

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "F5 Distributed Cloud Tools",
   "description": "Manage F5 Distributed Cloud resources directly from VS Code",
   "version": "0.1.14",
-  "publisher": "vscode-f5xc-tools",
+  "publisher": "RobinMordasiewicz",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Update publisher ID to `RobinMordasiewicz` to match existing marketplace account
- Extension identifier will be: `RobinMordasiewicz.vscode-f5xc-tools`

## Test plan
- [x] VS_MARKETPLACE_TOKEN secret updated for RobinMordasiewicz publisher
- [ ] Verify extension publishes under correct ID on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)