### PR TITLE
feat: add namespace-aware api support for resource operations

### DIFF
--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -38,7 +38,14 @@ export function registerCrudCommands(
         }
 
         const client = await profileManager.getClient(data.profileName);
-        const resource = await client.get(data.namespace, data.resourceType.apiPath, data.name);
+        const apiBase = data.resourceType.apiBase || 'config';
+        const resource = await client.get(
+          data.namespace,
+          data.resourceType.apiPath,
+          data.name,
+          undefined,
+          apiBase,
+        );
 
         // Apply view mode filtering
         const viewMode = getViewMode();
@@ -219,11 +226,12 @@ export function registerCrudCommands(
         }
 
         const client = await profileManager.getClient(activeProfile.name);
+        const apiBase = resourceType.apiBase || 'config';
 
         // Try to get existing resource to determine create vs update
         let exists = false;
         try {
-          await client.get(namespace, resourceType.apiPath, name);
+          await client.get(namespace, resourceType.apiPath, name, undefined, apiBase);
           exists = true;
         } catch {
           exists = false;
@@ -252,9 +260,9 @@ export function registerCrudCommands(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
             const resourceData = resource as any;
             if (exists) {
-              await client.replace(namespace, resourceType.apiPath, name, resourceData);
+              await client.replace(namespace, resourceType.apiPath, name, resourceData, apiBase);
             } else {
-              await client.create(namespace, resourceType.apiPath, resourceData);
+              await client.create(namespace, resourceType.apiPath, resourceData, apiBase);
             }
           },
         );
@@ -289,6 +297,7 @@ export function registerCrudCommands(
         }
 
         const client = await profileManager.getClient(data.profileName);
+        const apiBase = data.resourceType.apiBase || 'config';
 
         await vscode.window.withProgress(
           {
@@ -297,7 +306,13 @@ export function registerCrudCommands(
             cancellable: false,
           },
           async () => {
-            await client.delete(data.namespace, data.resourceType.apiPath, data.name);
+            await client.delete(
+              data.namespace,
+              data.resourceType.apiPath,
+              data.name,
+              false,
+              apiBase,
+            );
           },
         );
 
@@ -319,7 +334,14 @@ export function registerCrudCommands(
           // Called from tree view
           const data = node.getData();
           const client = await profileManager.getClient(data.profileName);
-          const resource = await client.get(data.namespace, data.resourceType.apiPath, data.name);
+          const apiBase = data.resourceType.apiBase || 'config';
+          const resource = await client.get(
+            data.namespace,
+            data.resourceType.apiPath,
+            data.name,
+            undefined,
+            apiBase,
+          );
           remoteContent = JSON.stringify(resource, null, 2);
           name = data.name;
 
@@ -377,7 +399,14 @@ export function registerCrudCommands(
           }
 
           const client = await profileManager.getClient(activeProfile.name);
-          const remoteResource = await client.get(namespace, resourceType.apiPath, name);
+          const apiBase = resourceType.apiBase || 'config';
+          const remoteResource = await client.get(
+            namespace,
+            resourceType.apiPath,
+            name,
+            undefined,
+            apiBase,
+          );
           remoteContent = JSON.stringify(remoteResource, null, 2);
         }
 
@@ -421,7 +450,14 @@ export function registerCrudCommands(
       await withErrorHandling(async () => {
         const data = node.getData();
         const client = await profileManager.getClient(data.profileName);
-        const resource = await client.get(data.namespace, data.resourceType.apiPath, data.name);
+        const apiBase = data.resourceType.apiBase || 'config';
+        const resource = await client.get(
+          data.namespace,
+          data.resourceType.apiPath,
+          data.name,
+          undefined,
+          apiBase,
+        );
 
         // Apply view mode filtering
         const viewMode = getViewMode();

--- a/src/providers/f5xcFileSystemProvider.ts
+++ b/src/providers/f5xcFileSystemProvider.ts
@@ -130,9 +130,16 @@ export class F5XCFileSystemProvider implements vscode.FileSystemProvider {
 
     try {
       const client = await this.profileManager.getClient(profileName);
+      const apiBase = resourceTypeInfo.apiBase || 'config';
 
       // Get the full resource (without GET_RSP_FORMAT_FOR_REPLACE which returns spec-only)
-      const response = await client.get(namespace, resourceTypeInfo.apiPath, resourceName);
+      const response = await client.get(
+        namespace,
+        resourceTypeInfo.apiPath,
+        resourceName,
+        undefined,
+        apiBase,
+      );
 
       // Handle different F5 XC API response structures
       const responseAny = response as unknown as Record<string, unknown>;
@@ -298,6 +305,7 @@ export class F5XCFileSystemProvider implements vscode.FileSystemProvider {
     // Apply to F5 XC
     try {
       const client = await this.profileManager.getClient(profileName);
+      const apiBase = resourceTypeInfo.apiBase || 'config';
 
       await vscode.window.withProgress(
         {
@@ -306,7 +314,13 @@ export class F5XCFileSystemProvider implements vscode.FileSystemProvider {
           cancellable: false,
         },
         async () => {
-          await client.replace(namespace, resourceTypeInfo.apiPath, resourceName, requestBody);
+          await client.replace(
+            namespace,
+            resourceTypeInfo.apiPath,
+            resourceName,
+            requestBody,
+            apiBase,
+          );
         },
       );
 


### PR DESCRIPTION
## Summary
- Adds namespace-aware API support for resource operations
- Enables resources to use different API bases (config vs web)
- Supports custom list endpoints, tenant-level resources, and non-standard responses
- Updates tree explorer to filter resources by namespace scope

## Changes
- **src/api/client.ts**: Add ListOptions interface, buildApiPath helper, listWithOptions method
- **src/tree/f5xcExplorer.ts**: Use namespace-filtered resource types
- **src/commands/crud.ts**: Pass apiBase from resource type config to all operations
- **src/providers/f5xcFileSystemProvider.ts**: Use apiBase for read/write operations

## Test plan
- [ ] Verify existing resources still display correctly
- [ ] Verify system namespace resources appear in correct locations
- [ ] Verify SMSv2 sites are visible in system namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)