### PR TITLE
feat: add describe resource command with webview panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,12 @@
         "icon": "$(eye)"
       },
       {
+        "command": "f5xc.describe",
+        "title": "Describe Resource",
+        "category": "F5 XC",
+        "icon": "$(info)"
+      },
+      {
         "command": "f5xc.edit",
         "title": "Edit Resource",
         "category": "F5 XC",
@@ -258,14 +264,19 @@
           "group": "1_resource@1"
         },
         {
-          "command": "f5xc.edit",
+          "command": "f5xc.describe",
           "when": "view == f5xc.explorer && viewItem =~ /resource:/",
           "group": "1_resource@2"
         },
         {
-          "command": "f5xc.delete",
+          "command": "f5xc.edit",
           "when": "view == f5xc.explorer && viewItem =~ /resource:/",
           "group": "1_resource@3"
+        },
+        {
+          "command": "f5xc.delete",
+          "when": "view == f5xc.explorer && viewItem =~ /resource:/",
+          "group": "1_resource@4"
         },
         {
           "command": "f5xc.diff",

--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -3,6 +3,7 @@ import { F5XCExplorerProvider, ResourceNode } from '../tree/f5xcExplorer';
 import { ProfileManager } from '../config/profiles';
 import { F5XCFileSystemProvider } from '../providers/f5xcFileSystemProvider';
 import { F5XCViewProvider } from '../providers/f5xcViewProvider';
+import { F5XCDescribeProvider } from '../providers/f5xcDescribeProvider';
 import { withErrorHandling, showInfo, showWarning } from '../utils/errors';
 import { getLogger } from '../utils/logger';
 import { RESOURCE_TYPES, getResourceTypeByApiPath } from '../api/resourceTypes';
@@ -26,6 +27,7 @@ export function registerCrudCommands(
   profileManager: ProfileManager,
   fsProvider: F5XCFileSystemProvider,
   viewProvider: F5XCViewProvider,
+  describeProvider: F5XCDescribeProvider,
 ): void {
   // GET - View resource as JSON (read-only)
   context.subscriptions.push(
@@ -57,6 +59,24 @@ export function registerCrudCommands(
         const viewMode = getViewMode();
         logger.info(`Viewing resource: ${data.name} (view mode: ${viewMode})`);
       }, 'View resource');
+    }),
+  );
+
+  // DESCRIBE - Show formatted resource description in WebView
+  context.subscriptions.push(
+    vscode.commands.registerCommand('f5xc.describe', async (node: ResourceNode) => {
+      await withErrorHandling(async () => {
+        const data = node.getData();
+
+        await describeProvider.showDescribe(
+          data.profileName,
+          data.namespace,
+          data.resourceType.apiPath,
+          data.name,
+        );
+
+        logger.info(`Describing resource: ${data.name}`);
+      }, 'Describe resource');
     }),
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { F5XCExplorerProvider } from './tree/f5xcExplorer';
 import { ProfilesProvider } from './tree/profilesProvider';
 import { F5XCFileSystemProvider } from './providers/f5xcFileSystemProvider';
 import { F5XCViewProvider } from './providers/f5xcViewProvider';
+import { F5XCDescribeProvider } from './providers/f5xcDescribeProvider';
 import { registerCrudCommands } from './commands/crud';
 import { registerProfileCommands } from './commands/profile';
 import { registerObservabilityCommands } from './commands/observability';
@@ -46,6 +47,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.workspace.registerTextDocumentContentProvider('f5xc-view', viewProvider),
   );
 
+  // Initialize the describe provider for formatted resource descriptions
+  const describeProvider = new F5XCDescribeProvider(profileManager);
+
   // Register tree views
   const explorerView = vscode.window.createTreeView('f5xc.explorer', {
     treeDataProvider: explorerProvider,
@@ -71,7 +75,14 @@ export function activate(context: vscode.ExtensionContext): void {
   registerProfileCommands(context, profileManager, profilesProvider, explorerProvider);
 
   // Register CRUD commands
-  registerCrudCommands(context, explorerProvider, profileManager, fsProvider, viewProvider);
+  registerCrudCommands(
+    context,
+    explorerProvider,
+    profileManager,
+    fsProvider,
+    viewProvider,
+    describeProvider,
+  );
 
   // Register observability commands
   registerObservabilityCommands(context, profileManager);

--- a/src/providers/f5xcDescribeProvider.ts
+++ b/src/providers/f5xcDescribeProvider.ts
@@ -1,0 +1,378 @@
+import * as vscode from 'vscode';
+import { ProfileManager } from '../config/profiles';
+import { RESOURCE_TYPES, ResourceTypeInfo } from '../api/resourceTypes';
+import { getLogger } from '../utils/logger';
+
+const logger = getLogger();
+
+/**
+ * WebView provider for displaying F5 XC resource descriptions.
+ * Shows formatted metadata, labels, annotations, status, and spec
+ * in a table-like format similar to kubectl describe output.
+ */
+export class F5XCDescribeProvider {
+  private panel: vscode.WebviewPanel | undefined;
+
+  constructor(private readonly profileManager: ProfileManager) {}
+
+  /**
+   * Find ResourceTypeInfo by API path
+   */
+  private findResourceTypeInfo(apiPath: string): ResourceTypeInfo | undefined {
+    for (const [, info] of Object.entries(RESOURCE_TYPES)) {
+      if (info.apiPath === apiPath) {
+        return info;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Show the describe panel for a resource
+   */
+  async showDescribe(
+    profileName: string,
+    namespace: string,
+    resourceType: string,
+    resourceName: string,
+  ): Promise<void> {
+    try {
+      logger.debug(`Describing resource: ${resourceName} (${resourceType})`);
+
+      const client = await this.profileManager.getClient(profileName);
+      const resourceTypeInfo = this.findResourceTypeInfo(resourceType);
+      const apiBase = resourceTypeInfo?.apiBase || 'config';
+      const displayName = resourceTypeInfo?.displayName || resourceType;
+
+      // Fetch full resource (not filtered)
+      const resource = await client.get(namespace, resourceType, resourceName, undefined, apiBase);
+
+      // Create or reveal the webview panel
+      if (this.panel) {
+        this.panel.reveal(vscode.ViewColumn.Beside);
+      } else {
+        this.panel = vscode.window.createWebviewPanel(
+          'f5xcDescribe',
+          `Describe: ${resourceName}`,
+          vscode.ViewColumn.Beside,
+          {
+            enableScripts: false,
+            retainContextWhenHidden: true,
+          },
+        );
+
+        this.panel.onDidDispose(() => {
+          this.panel = undefined;
+        });
+      }
+
+      // Update panel title and content
+      this.panel.title = `Describe: ${resourceName}`;
+      this.panel.webview.html = this.getWebviewContent(
+        resource as unknown as Record<string, unknown>,
+        resourceName,
+        displayName,
+        namespace,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to describe resource: ${message}`);
+      void vscode.window.showErrorMessage(`Failed to describe resource: ${message}`);
+    }
+  }
+
+  /**
+   * Generate HTML content for the webview
+   */
+  private getWebviewContent(
+    resource: Record<string, unknown>,
+    resourceName: string,
+    resourceType: string,
+    namespace: string,
+  ): string {
+    const metadata = resource.metadata as Record<string, unknown> | undefined;
+    const systemMetadata = resource.system_metadata as Record<string, unknown> | undefined;
+    const spec = resource.spec as Record<string, unknown> | undefined;
+
+    const sections: string[] = [];
+
+    // Header
+    sections.push(`
+      <h2>${this.escapeHtml(resourceType)}: ${this.escapeHtml(resourceName)}</h2>
+    `);
+
+    // Metadata section
+    sections.push(this.renderSection('Metadata', this.renderMetadata(metadata, namespace)));
+
+    // Labels section
+    const labels = metadata?.labels as Record<string, string> | undefined;
+    if (labels && Object.keys(labels).length > 0) {
+      sections.push(this.renderSection('Labels', this.renderKeyValuePairs(labels)));
+    }
+
+    // Annotations section
+    const annotations = metadata?.annotations as Record<string, string> | undefined;
+    if (annotations && Object.keys(annotations).length > 0) {
+      sections.push(this.renderSection('Annotations', this.renderKeyValuePairs(annotations)));
+    }
+
+    // System Metadata / Status section
+    if (systemMetadata) {
+      sections.push(this.renderSection('Status', this.renderSystemMetadata(systemMetadata)));
+    }
+
+    // Spec section (top-level fields only)
+    if (spec) {
+      sections.push(this.renderSection('Spec', this.renderSpec(spec)));
+    }
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: var(--vscode-font-family);
+      font-size: var(--vscode-font-size);
+      color: var(--vscode-editor-foreground);
+      background-color: var(--vscode-editor-background);
+      padding: 16px;
+      line-height: 1.5;
+    }
+    h2 {
+      color: var(--vscode-editor-foreground);
+      border-bottom: 1px solid var(--vscode-panel-border);
+      padding-bottom: 8px;
+      margin-top: 0;
+    }
+    .section {
+      margin-bottom: 24px;
+    }
+    .section-header {
+      font-weight: bold;
+      color: var(--vscode-symbolIcon-classForeground);
+      margin: 16px 0 8px;
+      font-size: 1.1em;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    tr {
+      border-bottom: 1px solid var(--vscode-panel-border);
+    }
+    tr:last-child {
+      border-bottom: none;
+    }
+    td {
+      padding: 6px 12px 6px 0;
+      vertical-align: top;
+    }
+    .key {
+      color: var(--vscode-symbolIcon-fieldForeground);
+      font-weight: 500;
+      width: 200px;
+      white-space: nowrap;
+    }
+    .value {
+      color: var(--vscode-editor-foreground);
+      word-break: break-word;
+    }
+    .value-none {
+      color: var(--vscode-disabledForeground);
+      font-style: italic;
+    }
+    .nested-value {
+      background-color: var(--vscode-textBlockQuote-background);
+      padding: 8px;
+      border-radius: 4px;
+      font-family: var(--vscode-editor-font-family);
+      font-size: 0.9em;
+      white-space: pre-wrap;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  ${sections.join('\n')}
+</body>
+</html>`;
+  }
+
+  /**
+   * Render a section with header
+   */
+  private renderSection(title: string, content: string): string {
+    return `
+      <div class="section">
+        <div class="section-header">${this.escapeHtml(title)}</div>
+        ${content}
+      </div>
+    `;
+  }
+
+  /**
+   * Render metadata fields
+   */
+  private renderMetadata(metadata: Record<string, unknown> | undefined, namespace: string): string {
+    const rows: string[] = [];
+
+    rows.push(this.renderRow('Name', metadata?.name as string | undefined));
+    rows.push(this.renderRow('Namespace', namespace));
+    rows.push(this.renderRow('UID', metadata?.uid as string | undefined));
+    rows.push(
+      this.renderRow(
+        'Creation Time',
+        this.formatTimestamp(metadata?.creation_timestamp as string | undefined),
+      ),
+    );
+    rows.push(this.renderRow('Creator', metadata?.creator_id as string | undefined));
+    rows.push(this.renderRow('Description', metadata?.description as string | undefined));
+
+    return `<table>${rows.join('\n')}</table>`;
+  }
+
+  /**
+   * Render system metadata / status fields
+   */
+  private renderSystemMetadata(systemMetadata: Record<string, unknown>): string {
+    const rows: string[] = [];
+
+    rows.push(this.renderRow('State', systemMetadata.state as string | undefined));
+    rows.push(
+      this.renderRow(
+        'Last Modified',
+        this.formatTimestamp(systemMetadata.modification_timestamp as string | undefined),
+      ),
+    );
+    rows.push(this.renderRow('Modified By', systemMetadata.modifier_id as string | undefined));
+    rows.push(this.renderRow('Tenant', systemMetadata.tenant as string | undefined));
+
+    // Object index for internal tracking
+    const objectIndex = systemMetadata.object_index as number | undefined;
+    if (objectIndex !== undefined) {
+      rows.push(this.renderRow('Object Index', String(objectIndex)));
+    }
+
+    // Finalizers
+    const finalizers = systemMetadata.finalizers as string[] | undefined;
+    if (finalizers && finalizers.length > 0) {
+      rows.push(this.renderRow('Finalizers', finalizers.join(', ')));
+    }
+
+    return `<table>${rows.join('\n')}</table>`;
+  }
+
+  /**
+   * Render spec fields (top-level only, complex objects shown as JSON)
+   */
+  private renderSpec(spec: Record<string, unknown>): string {
+    const rows: string[] = [];
+
+    for (const [key, value] of Object.entries(spec)) {
+      if (value === null || value === undefined) {
+        continue;
+      }
+
+      const displayKey = this.formatKey(key);
+
+      if (typeof value === 'object') {
+        // Show complex objects as formatted JSON
+        const jsonValue = JSON.stringify(value, null, 2);
+        rows.push(this.renderRow(displayKey, jsonValue, true));
+      } else {
+        rows.push(this.renderRow(displayKey, String(value)));
+      }
+    }
+
+    if (rows.length === 0) {
+      return '<p class="value-none">No spec fields</p>';
+    }
+
+    return `<table>${rows.join('\n')}</table>`;
+  }
+
+  /**
+   * Render key-value pairs (labels, annotations)
+   */
+  private renderKeyValuePairs(pairs: Record<string, string>): string {
+    const rows: string[] = [];
+
+    for (const [key, value] of Object.entries(pairs)) {
+      rows.push(this.renderRow(key, value));
+    }
+
+    if (rows.length === 0) {
+      return '<p class="value-none">None</p>';
+    }
+
+    return `<table>${rows.join('\n')}</table>`;
+  }
+
+  /**
+   * Render a single table row
+   */
+  private renderRow(key: string, value: string | undefined, isNested = false): string {
+    const displayValue =
+      value !== undefined && value !== ''
+        ? isNested
+          ? `<div class="nested-value">${this.escapeHtml(value)}</div>`
+          : this.escapeHtml(value)
+        : '<span class="value-none">-</span>';
+
+    return `
+      <tr>
+        <td class="key">${this.escapeHtml(key)}</td>
+        <td class="value">${displayValue}</td>
+      </tr>
+    `;
+  }
+
+  /**
+   * Format a key for display (snake_case to Title Case)
+   */
+  private formatKey(key: string): string {
+    return key
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  }
+
+  /**
+   * Format a timestamp for display
+   */
+  private formatTimestamp(timestamp: string | undefined): string | undefined {
+    if (!timestamp) {
+      return undefined;
+    }
+
+    try {
+      const date = new Date(timestamp);
+      return date.toLocaleString();
+    } catch {
+      return timestamp;
+    }
+  }
+
+  /**
+   * Escape HTML special characters
+   */
+  private escapeHtml(text: string): string {
+    const htmlEscapes: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    };
+    return text.replace(/[&<>"']/g, (char) => htmlEscapes[char] || char);
+  }
+
+  /**
+   * Dispose of the webview panel
+   */
+  dispose(): void {
+    this.panel?.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new "Describe Resource" context menu option that displays resource information in a formatted table-like view similar to kubectl describe output
- Uses VS Code WebView panel with proper theme support via CSS variables

## Changes
- Add `F5XCDescribeProvider` with WebView panel for formatted display
- Add `f5xc.describe` command and context menu entry
- Display sections: Metadata, Labels, Annotations, Status, Spec
- Complex spec objects shown as formatted JSON

## Test plan
- [ ] Build extension: `npm run compile`
- [ ] Launch Extension Development Host (F5)
- [ ] Right-click any resource in the tree view
- [ ] Click "Describe Resource"
- [ ] Verify WebView panel opens with formatted sections
- [ ] Check VS Code theme colors apply correctly (dark/light modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)