### PR TITLE
feat: make describe resource the default single-click action

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,12 +259,12 @@
           "group": "inline"
         },
         {
-          "command": "f5xc.get",
+          "command": "f5xc.describe",
           "when": "view == f5xc.explorer && viewItem =~ /resource:/",
           "group": "1_resource@1"
         },
         {
-          "command": "f5xc.describe",
+          "command": "f5xc.get",
           "when": "view == f5xc.explorer && viewItem =~ /resource:/",
           "group": "1_resource@2"
         },

--- a/src/tree/f5xcExplorer.ts
+++ b/src/tree/f5xcExplorer.ts
@@ -329,8 +329,8 @@ export class ResourceNode implements F5XCTreeItem {
     item.iconPath = new vscode.ThemeIcon('file');
     item.tooltip = `${this.data.resourceType.displayName}: ${this.data.name}\nNamespace: ${this.data.namespace}\nCategory: ${this.data.resourceType.category}`;
     item.command = {
-      command: 'f5xc.get',
-      title: 'View Resource',
+      command: 'f5xc.describe',
+      title: 'Describe Resource',
       arguments: [this],
     };
     return item;


### PR DESCRIPTION
## Summary
- Single-click on resource now opens the formatted Describe WebView instead of JSON view
- Swapped context menu order so "Describe Resource" appears first
- "View Resource" (JSON) remains accessible via right-click menu

## Test plan
- [ ] Single-click a resource → Should open Describe WebView
- [ ] Right-click a resource → "Describe Resource" should be first in menu
- [ ] Select "View Resource" from context menu → Should open JSON view

🤖 Generated with [Claude Code](https://claude.com/claude-code)