### PR TITLE
fix: use cached list data for users without get endpoint

### DIFF
--- a/src/api/resourceTypes.ts
+++ b/src/api/resourceTypes.ts
@@ -87,12 +87,20 @@ export interface ResourceTypeInfo {
   serviceSegment?: string;
   /** Custom list endpoint path (overrides standard path construction) */
   customListPath?: string;
+  /** Custom get endpoint path (overrides standard path construction, use {namespace} and {name} placeholders) */
+  customGetPath?: string;
   /** HTTP method for list operation - some APIs use POST instead of GET (default: 'GET') */
   listMethod?: 'GET' | 'POST';
   /** Whether this is a tenant-level resource (no namespace in path) */
   tenantLevel?: boolean;
   /** Response field containing list items (default: 'items') */
   listResponseField?: string;
+  /** Skip namespace filtering for non-standard APIs (e.g., SCIM) that don't include namespace in response */
+  skipNamespaceFilter?: boolean;
+  /** Use cached list data for describe instead of making a GET call (for APIs without GET endpoint) */
+  useListDataForDescribe?: boolean;
+  /** Resource requires SCIM Bearer token authentication (not standard API token) */
+  requiresScimAuth?: boolean;
 }
 
 /**
@@ -120,12 +128,20 @@ interface ResourceTypeOverride {
   apiBase?: ApiBase;
   /** Custom list endpoint path */
   customListPath?: string;
+  /** Custom get endpoint path */
+  customGetPath?: string;
   /** HTTP method for list operation */
   listMethod?: 'GET' | 'POST';
   /** Whether this is a tenant-level resource */
   tenantLevel?: boolean;
   /** Response field containing list items */
   listResponseField?: string;
+  /** Skip namespace filtering for non-standard APIs */
+  skipNamespaceFilter?: boolean;
+  /** Use cached list data for describe instead of making a GET call */
+  useListDataForDescribe?: boolean;
+  /** Resource requires SCIM Bearer token authentication */
+  requiresScimAuth?: boolean;
 }
 
 /**
@@ -375,9 +391,10 @@ const RESOURCE_TYPE_OVERRIDES: Record<string, ResourceTypeOverride> = {
     icon: 'person',
     namespaceScope: 'system',
     apiBase: 'web',
-    customListPath: '/api/scim/v2/Users',
+    customListPath: '/api/web/custom/namespaces/{namespace}/user_roles',
     listMethod: 'GET',
-    listResponseField: 'Resources',
+    skipNamespaceFilter: true,
+    useListDataForDescribe: true,
   },
   role: {
     category: ResourceCategory.IAM,
@@ -465,9 +482,13 @@ function mergeResourceType(
     // Include service segment for extended API paths (e.g., /api/config/dns/...)
     serviceSegment: (generated as { serviceSegment?: string } | undefined)?.serviceSegment,
     customListPath: override.customListPath,
+    customGetPath: override.customGetPath,
     listMethod: override.listMethod,
     tenantLevel: override.tenantLevel,
     listResponseField: override.listResponseField,
+    skipNamespaceFilter: override.skipNamespaceFilter,
+    useListDataForDescribe: override.useListDataForDescribe,
+    requiresScimAuth: override.requiresScimAuth,
   };
 
   return result;

--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -96,6 +96,7 @@ export function registerCrudCommands(
           data.namespace,
           data.resourceType.apiPath,
           data.name,
+          data.fullResourceData,
         );
 
         logger.info(`Describing resource: ${data.name}`);

--- a/src/providers/f5xcViewProvider.ts
+++ b/src/providers/f5xcViewProvider.ts
@@ -106,7 +106,10 @@ export class F5XCViewProvider implements vscode.TextDocumentContentProvider {
       const resourceTypeInfo = this.findResourceTypeInfo(resourceType);
       const apiBase = resourceTypeInfo?.apiBase || 'config';
 
-      const resource = await client.get(namespace, resourceType, resourceName, undefined, apiBase);
+      const resource = await client.getWithOptions(namespace, resourceType, resourceName, {
+        apiBase,
+        customGetPath: resourceTypeInfo?.customGetPath,
+      });
 
       // Apply view mode filtering
       const viewMode = getViewMode();

--- a/src/tree/treeTypes.ts
+++ b/src/tree/treeTypes.ts
@@ -60,4 +60,6 @@ export interface ResourceNodeData {
   resourceTypeKey: string;
   profileName: string;
   metadata?: Record<string, unknown>;
+  /** Full resource data from list response (for resources without GET endpoint) */
+  fullResourceData?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Fixes 404 error when clicking on a user in the tree view
- Users resource type now uses cached list data since there's no GET endpoint for individual users
- Adds `useListDataForDescribe` and `skipNamespaceFilter` flags for resources without standard GET endpoints

## Changes
- Added `getWithOptions` method to client for custom API paths
- Added `useListDataForDescribe` flag to use cached list response data
- Added `skipNamespaceFilter` flag for APIs without namespace metadata  
- Updated tree nodes to store `fullResourceData` for describe operations
- Updated describe provider to use cached data when available

## Test plan
- [x] Build extension successfully
- [x] Navigate to System → Identity & Access → Users
- [x] Verify users are listed
- [x] Click on a user - should display user details from cached data instead of 404 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)