### PR TITLE
ci: automatically trigger Release workflow after semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,33 @@ jobs:
         run: npm ci
 
       - name: Run semantic-release
+        id: semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GH_TOKEN }}
           HUSKY: 0
-        run: npx semantic-release
+        run: |
+          # Run semantic-release and capture output
+          OUTPUT=$(npx semantic-release 2>&1) || true
+          echo "$OUTPUT"
+
+          # Check if a new version was published
+          if echo "$OUTPUT" | grep -q "Published release"; then
+            # Extract the version from the output
+            VERSION=$(echo "$OUTPUT" | grep -oP "Published release \K[0-9]+\.[0-9]+\.[0-9]+")
+            echo "new_release=true" >> $GITHUB_OUTPUT
+            echo "new_version=$VERSION" >> $GITHUB_OUTPUT
+            echo "✅ New version published: $VERSION"
+          else
+            echo "new_release=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No new version published"
+          fi
+
+      - name: Trigger Release workflow
+        if: steps.semantic-release.outputs.new_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GH_TOKEN }}
+        run: |
+          VERSION="${{ steps.semantic-release.outputs.new_version }}"
+          echo "🚀 Triggering Release workflow for v${VERSION}"
+          gh workflow run release.yml --ref "v${VERSION}"
+          echo "✅ Release workflow triggered successfully"


### PR DESCRIPTION
## Summary
- Automatically triggers the Release workflow after semantic-release creates a new tag
- Fixes issue where tags created with GITHUB_TOKEN don't trigger other workflows (GitHub security feature)
- Uses RELEASE_PAT with fallback to GH_TOKEN for compatibility

## How it works
1. After `npx semantic-release` runs, the output is parsed to detect if a new version was published
2. If a new version is detected, the Release workflow is triggered using `gh workflow run`
3. This ensures VS Code Marketplace and Open VSX Registry are automatically updated

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, any new semantic-release version should trigger the Release workflow automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)