### PR TITLE
feat: add pop details webview with geographic coordinates

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,6 +252,24 @@
         "title": "View Maintenance Details",
         "category": "F5 XC",
         "icon": "$(info)"
+      },
+      {
+        "command": "f5xc.cloudStatus.viewIncident",
+        "title": "View Incident Details",
+        "category": "F5 XC",
+        "icon": "$(warning)"
+      },
+      {
+        "command": "f5xc.cloudStatus.viewComponent",
+        "title": "View Service Details",
+        "category": "F5 XC",
+        "icon": "$(server)"
+      },
+      {
+        "command": "f5xc.cloudStatus.viewPoP",
+        "title": "View PoP Details",
+        "category": "F5 XC",
+        "icon": "$(globe)"
       }
     ],
     "menus": {

--- a/src/api/geocoder.ts
+++ b/src/api/geocoder.ts
@@ -1,0 +1,54 @@
+/**
+ * Geocoder Module
+ * Nominatim (OpenStreetMap) geocoding wrapper for location lookup
+ */
+
+import { Coordinates } from './popCoordinates';
+import { getLogger } from '../utils/logger';
+
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search';
+const logger = getLogger();
+
+/**
+ * Geocode a location string using Nominatim (OpenStreetMap)
+ * Free, no API key required, 1 request/second rate limit
+ * @param query Location query string (e.g., "Ashburn, VA, United States")
+ * @returns Coordinates or null if geocoding fails
+ */
+export async function geocodeLocation(query: string): Promise<Coordinates | null> {
+  try {
+    const params = new URLSearchParams({
+      q: query,
+      format: 'json',
+      limit: '1',
+    });
+
+    const response = await fetch(`${NOMINATIM_URL}?${params.toString()}`, {
+      headers: {
+        'User-Agent': 'VSCode-F5XC-Tools/1.0',
+      },
+    });
+
+    if (!response.ok) {
+      logger.warn(`Nominatim geocoding failed with status ${response.status} for query: ${query}`);
+      return null;
+    }
+
+    const results = (await response.json()) as Array<{ lat: string; lon: string }>;
+    const firstResult = results[0];
+    if (firstResult) {
+      const coords = {
+        latitude: parseFloat(firstResult.lat),
+        longitude: parseFloat(firstResult.lon),
+      };
+      logger.debug(`Geocoded "${query}" to ${coords.latitude}, ${coords.longitude}`);
+      return coords;
+    }
+
+    logger.debug(`No geocoding results for query: ${query}`);
+    return null;
+  } catch (error) {
+    logger.warn(`Geocoding error for "${query}":`, error);
+    return null;
+  }
+}

--- a/src/api/popCoordinates.ts
+++ b/src/api/popCoordinates.ts
@@ -1,0 +1,126 @@
+/**
+ * PoP Coordinates Module
+ * Static mapping of known F5 Regional Edge PoP coordinates with geocoding fallback support
+ */
+
+export interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * Static mapping of known F5 Regional Edge PoP locations
+ * Site codes extracted from Cloud Status names (e.g., "dc12" from "Ashburn (dc12)")
+ */
+export const POP_COORDINATES: Record<string, Coordinates> = {
+  // North America
+  dc12: { latitude: 39.0438, longitude: -77.4874 }, // Ashburn, VA
+  sv10: { latitude: 37.3861, longitude: -122.0839 }, // Santa Clara, CA
+  se4: { latitude: 47.6062, longitude: -122.3321 }, // Seattle, WA
+  ch2: { latitude: 41.8781, longitude: -87.6298 }, // Chicago, IL
+  da3: { latitude: 32.7767, longitude: -96.797 }, // Dallas, TX
+  ny8: { latitude: 40.7128, longitude: -74.006 }, // New York, NY
+  la3: { latitude: 34.0522, longitude: -118.2437 }, // Los Angeles, CA
+  at2: { latitude: 33.749, longitude: -84.388 }, // Atlanta, GA
+  mi3: { latitude: 25.7617, longitude: -80.1918 }, // Miami, FL
+  mo2: { latitude: 45.5017, longitude: -73.5673 }, // Montreal, Canada
+  to2: { latitude: 43.6532, longitude: -79.3832 }, // Toronto, Canada
+
+  // Europe
+  fra: { latitude: 50.1109, longitude: 8.6821 }, // Frankfurt, Germany
+  ld5: { latitude: 51.5074, longitude: -0.1278 }, // London, UK
+  pa4: { latitude: 48.8566, longitude: 2.3522 }, // Paris, France
+  am2: { latitude: 52.3676, longitude: 4.9041 }, // Amsterdam, Netherlands
+  mu2: { latitude: 48.1351, longitude: 11.582 }, // Munich, Germany
+  st2: { latitude: 59.3293, longitude: 18.0686 }, // Stockholm, Sweden
+  ma2: { latitude: 40.4168, longitude: -3.7038 }, // Madrid, Spain
+  mi5: { latitude: 45.4642, longitude: 9.19 }, // Milan, Italy
+
+  // Asia Pacific
+  sg3: { latitude: 1.3521, longitude: 103.8198 }, // Singapore
+  ty8: { latitude: 35.6762, longitude: 139.6503 }, // Tokyo, Japan
+  os2: { latitude: 34.6937, longitude: 135.5023 }, // Osaka, Japan
+  sy4: { latitude: -33.8688, longitude: 151.2093 }, // Sydney, Australia
+  hk3: { latitude: 22.3193, longitude: 114.1694 }, // Hong Kong
+  mu3: { latitude: 19.076, longitude: 72.8777 }, // Mumbai, India
+  bl2: { latitude: 12.9716, longitude: 77.5946 }, // Bangalore, India
+
+  // South America
+  sp3: { latitude: -23.5505, longitude: -46.6333 }, // São Paulo, Brazil
+  ba2: { latitude: -34.6037, longitude: -58.3816 }, // Buenos Aires, Argentina
+
+  // Middle East & Africa
+  jb2: { latitude: 25.2048, longitude: 55.2708 }, // Dubai, UAE
+  jh2: { latitude: -26.2041, longitude: 28.0473 }, // Johannesburg, SA
+};
+
+/**
+ * Parse location components from Cloud Status PoP name
+ * Pattern: "City (code), State/Region, Country" or "City, Country" or "City"
+ */
+export function parsePopLocation(
+  popName: string,
+): { city: string; region?: string; country?: string } | null {
+  // Remove site code in parentheses first
+  const cleanName = popName.replace(/\s*\([^)]+\)/, '').trim();
+  const parts = cleanName.split(',').map((p) => p.trim());
+
+  if (parts.length === 0 || !parts[0]) {
+    return null;
+  }
+
+  const city = parts[0];
+
+  if (parts.length === 1) {
+    return { city };
+  } else if (parts.length === 2) {
+    return { city, country: parts[1] };
+  } else {
+    return { city, region: parts[1], country: parts[2] };
+  }
+}
+
+/**
+ * Get coordinates for a PoP - tries static map first, then optional geocoding fallback
+ * @param siteCode Site code extracted from PoP name (e.g., "dc12")
+ * @param popName Full PoP name for geocoding fallback
+ * @param geocoder Optional geocoding function for unknown PoPs
+ */
+export async function getPopCoordinates(
+  siteCode: string | null,
+  popName: string,
+  geocoder?: (query: string) => Promise<Coordinates | null>,
+): Promise<Coordinates | null> {
+  // 1. Try static mapping by site code
+  if (siteCode) {
+    const staticCoords = POP_COORDINATES[siteCode.toLowerCase()];
+    if (staticCoords) {
+      return staticCoords;
+    }
+  }
+
+  // 2. Fall back to geocoding if provided
+  if (geocoder) {
+    const location = parsePopLocation(popName);
+    if (location) {
+      const query = [location.city, location.region, location.country].filter(Boolean).join(', ');
+      return await geocoder(query);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Format coordinates for display
+ * @param coords Coordinates object or null
+ * @returns Formatted string like "39.0438°N, 77.4874°W" or "N/A"
+ */
+export function formatCoordinates(coords: Coordinates | null): string {
+  if (!coords) {
+    return 'N/A';
+  }
+  const latDir = coords.latitude >= 0 ? 'N' : 'S';
+  const lonDir = coords.longitude >= 0 ? 'E' : 'W';
+  return `${Math.abs(coords.latitude).toFixed(4)}°${latDir}, ${Math.abs(coords.longitude).toFixed(4)}°${lonDir}`;
+}

--- a/src/commands/cloudStatus.ts
+++ b/src/commands/cloudStatus.ts
@@ -44,4 +44,34 @@ export function registerCloudStatusCommands(
       );
     }),
   );
+
+  // View incident details in WebView
+  context.subscriptions.push(
+    vscode.commands.registerCommand('f5xc.cloudStatus.viewIncident', (incident: unknown) => {
+      dashboardProvider.showIncidentDetails(
+        incident as Parameters<typeof dashboardProvider.showIncidentDetails>[0],
+      );
+    }),
+  );
+
+  // View component details in WebView
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'f5xc.cloudStatus.viewComponent',
+      async (component: unknown) => {
+        await dashboardProvider.showComponentDetails(
+          component as Parameters<typeof dashboardProvider.showComponentDetails>[0],
+        );
+      },
+    ),
+  );
+
+  // View PoP (Regional Edge) details in WebView
+  context.subscriptions.push(
+    vscode.commands.registerCommand('f5xc.cloudStatus.viewPoP', async (component: unknown) => {
+      await dashboardProvider.showPoPDetails(
+        component as Parameters<typeof dashboardProvider.showPoPDetails>[0],
+      );
+    }),
+  );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext): void {
   const explorerProvider = new F5XCExplorerProvider(profileManager, clientFactory);
   const profilesProvider = new ProfilesProvider(profileManager);
   const cloudStatusProvider = new CloudStatusProvider();
-  const cloudStatusDashboardProvider = new CloudStatusDashboardProvider();
+  const cloudStatusDashboardProvider = new CloudStatusDashboardProvider(profileManager);
 
   // Initialize F5 XC file system provider for editing resources
   const fsProvider = new F5XCFileSystemProvider(profileManager, () => {

--- a/src/tree/cloudStatusProvider.ts
+++ b/src/tree/cloudStatusProvider.ts
@@ -12,6 +12,7 @@ import {
   ScheduledMaintenance,
   getStatusDisplayText,
   getIncidentStatusText,
+  isPoP,
 } from '../api/cloudStatus';
 import { CloudStatusTreeItem, CloudStatusContext } from './cloudStatusTypes';
 
@@ -201,10 +202,30 @@ class ComponentNode implements CloudStatusTreeItem {
     const item = new vscode.TreeItem(this.component.name, vscode.TreeItemCollapsibleState.None);
     item.contextValue = CloudStatusContext.COMPONENT;
     item.iconPath = getStatusIcon(this.component.status);
+
+    // Check if this is a PoP
+    const isPoPResult = isPoP(this.component);
+
     item.description = getStatusDisplayText(this.component.status);
+
     item.tooltip = new vscode.MarkdownString(
       `**${this.component.name}**\n\nStatus: ${getStatusDisplayText(this.component.status)}${this.component.description ? `\n\n${this.component.description}` : ''}`,
     );
+
+    // Use PoP-specific command for Regional Edge PoPs
+    if (isPoPResult) {
+      item.command = {
+        command: 'f5xc.cloudStatus.viewPoP',
+        title: 'View PoP Details',
+        arguments: [this.component],
+      };
+    } else {
+      item.command = {
+        command: 'f5xc.cloudStatus.viewComponent',
+        title: 'View Component Details',
+        arguments: [this.component],
+      };
+    }
     return item;
   }
 
@@ -262,9 +283,9 @@ class IncidentNode implements CloudStatusTreeItem {
 
     item.tooltip = new vscode.MarkdownString(tooltipContent);
     item.command = {
-      command: 'vscode.open',
-      title: 'Open Incident',
-      arguments: [vscode.Uri.parse(this.incident.shortlink)],
+      command: 'f5xc.cloudStatus.viewIncident',
+      title: 'View Incident Details',
+      arguments: [this.incident],
     };
     return item;
   }


### PR DESCRIPTION
## Summary
- Add detailed PoP/Regional Edge webview with status and location info
- Implement coordinate display using static mapping for known F5 PoPs (~30 locations)
- Add Nominatim (OpenStreetMap) geocoding fallback for unknown PoP locations
- Display site code, city, region, country, and coordinates in a styled webview

## New Files
- `src/api/popCoordinates.ts`: Static coordinate map + location parser + formatting utilities
- `src/api/geocoder.ts`: Nominatim geocoding wrapper (free, no API key required)

## Changes
- Enhanced `cloudStatusDashboardProvider.ts` with coordinate lookup and display
- Added PoP-specific click handlers in cloud status tree
- Extended F5XCClient with Regional Edge site lookup

## Test plan
- [ ] Click on a PoP in the Cloud Status tree (e.g., "Ashburn (dc12)")
- [ ] Verify coordinates display in the Location card (e.g., "39.0438°N, 77.4874°W")
- [ ] Test with both known PoPs (static map) and potentially unknown locations (geocoding fallback)
- [ ] Verify the webview displays all PoP details correctly

🤖 Generated with [Claude Code](https://claude.ai/code)