### PR TITLE
test: add unit tests for geocoder and pop coordinates modules

### DIFF
--- a/src/test/unit/geocoder.test.ts
+++ b/src/test/unit/geocoder.test.ts
@@ -1,0 +1,185 @@
+import { geocodeLocation } from '../../api/geocoder';
+
+// Mock the logger module
+jest.mock('../../utils/logger', () => ({
+  getLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('geocodeLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return coordinates for a valid location', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([
+        {
+          lat: '39.0438',
+          lon: '-77.4874',
+        },
+      ]),
+    });
+
+    const result = await geocodeLocation('Ashburn, VA, United States');
+
+    expect(result).toEqual({
+      latitude: 39.0438,
+      longitude: -77.4874,
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://nominatim.openstreetmap.org/search'),
+      expect.objectContaining({
+        headers: {
+          'User-Agent': 'VSCode-F5XC-Tools/1.0',
+        },
+      }),
+    );
+  });
+
+  it('should include correct query parameters', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([{ lat: '10', lon: '20' }]),
+    });
+
+    await geocodeLocation('Test City');
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('q=Test+City');
+    expect(calledUrl).toContain('format=json');
+    expect(calledUrl).toContain('limit=1');
+  });
+
+  it('should return null when no results found', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+
+    const result = await geocodeLocation('NonexistentPlace12345');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when response is not ok', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: jest.fn(),
+    });
+
+    const result = await geocodeLocation('Ashburn, VA');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when fetch throws an error', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const result = await geocodeLocation('Ashburn, VA');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when JSON parsing fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockRejectedValue(new Error('Invalid JSON')),
+    });
+
+    const result = await geocodeLocation('Ashburn, VA');
+
+    expect(result).toBeNull();
+  });
+
+  it('should parse coordinates as floats', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([
+        {
+          lat: '51.5074',
+          lon: '-0.1278',
+        },
+      ]),
+    });
+
+    const result = await geocodeLocation('London, UK');
+
+    expect(result).toEqual({
+      latitude: 51.5074,
+      longitude: -0.1278,
+    });
+    expect(typeof result?.latitude).toBe('number');
+    expect(typeof result?.longitude).toBe('number');
+  });
+
+  it('should handle negative coordinates', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([
+        {
+          lat: '-33.8688',
+          lon: '151.2093',
+        },
+      ]),
+    });
+
+    const result = await geocodeLocation('Sydney, Australia');
+
+    expect(result).toEqual({
+      latitude: -33.8688,
+      longitude: 151.2093,
+    });
+  });
+
+  it('should encode special characters in query', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([{ lat: '-23.5505', lon: '-46.6333' }]),
+    });
+
+    await geocodeLocation('São Paulo, Brazil');
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    // URLSearchParams should encode special characters
+    expect(calledUrl).toContain('S%C3%A3o+Paulo');
+  });
+
+  it('should return first result when multiple results returned', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([
+        { lat: '10.0', lon: '20.0' },
+        { lat: '30.0', lon: '40.0' },
+      ]),
+    });
+
+    const result = await geocodeLocation('Ambiguous City');
+
+    expect(result).toEqual({
+      latitude: 10.0,
+      longitude: 20.0,
+    });
+  });
+
+  it('should handle rate limiting (429 status)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+    });
+
+    const result = await geocodeLocation('Ashburn, VA');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/test/unit/popCoordinates.test.ts
+++ b/src/test/unit/popCoordinates.test.ts
@@ -1,0 +1,226 @@
+import {
+  Coordinates,
+  POP_COORDINATES,
+  parsePopLocation,
+  getPopCoordinates,
+  formatCoordinates,
+} from '../../api/popCoordinates';
+
+describe('POP_COORDINATES', () => {
+  it('should contain known PoP coordinates', () => {
+    expect(POP_COORDINATES).toHaveProperty('dc12');
+    expect(POP_COORDINATES).toHaveProperty('sv10');
+    expect(POP_COORDINATES).toHaveProperty('fra');
+    expect(POP_COORDINATES).toHaveProperty('sg3');
+  });
+
+  it('should have valid coordinate ranges', () => {
+    for (const [, coords] of Object.entries(POP_COORDINATES)) {
+      expect(coords.latitude).toBeGreaterThanOrEqual(-90);
+      expect(coords.latitude).toBeLessThanOrEqual(90);
+      expect(coords.longitude).toBeGreaterThanOrEqual(-180);
+      expect(coords.longitude).toBeLessThanOrEqual(180);
+    }
+  });
+
+  it('should have Ashburn coordinates for dc12', () => {
+    expect(POP_COORDINATES['dc12']).toEqual({
+      latitude: 39.0438,
+      longitude: -77.4874,
+    });
+  });
+});
+
+describe('parsePopLocation', () => {
+  it('should parse location with site code, city, state, and country', () => {
+    const result = parsePopLocation('Ashburn (dc12), VA, United States');
+    expect(result).toEqual({
+      city: 'Ashburn',
+      region: 'VA',
+      country: 'United States',
+    });
+  });
+
+  it('should parse location with city and country only', () => {
+    const result = parsePopLocation('Frankfurt, Germany');
+    expect(result).toEqual({
+      city: 'Frankfurt',
+      country: 'Germany',
+    });
+  });
+
+  it('should parse location with city only', () => {
+    const result = parsePopLocation('Singapore');
+    expect(result).toEqual({
+      city: 'Singapore',
+    });
+  });
+
+  it('should parse location with site code and city only', () => {
+    const result = parsePopLocation('Singapore (sg3)');
+    expect(result).toEqual({
+      city: 'Singapore',
+    });
+  });
+
+  it('should handle São Paulo with special characters', () => {
+    const result = parsePopLocation('São Paulo (sp3), Brazil');
+    expect(result).toEqual({
+      city: 'São Paulo',
+      country: 'Brazil',
+    });
+  });
+
+  it('should return null for empty string', () => {
+    const result = parsePopLocation('');
+    expect(result).toBeNull();
+  });
+
+  it('should return null for whitespace only', () => {
+    const result = parsePopLocation('   ');
+    expect(result).toBeNull();
+  });
+
+  it('should trim whitespace from parts', () => {
+    const result = parsePopLocation('  London  ,  UK  ');
+    expect(result).toEqual({
+      city: 'London',
+      country: 'UK',
+    });
+  });
+});
+
+describe('getPopCoordinates', () => {
+  it('should return coordinates from static map when site code is found', async () => {
+    const result = await getPopCoordinates('dc12', 'Ashburn (dc12), VA, United States');
+    expect(result).toEqual({
+      latitude: 39.0438,
+      longitude: -77.4874,
+    });
+  });
+
+  it('should return coordinates case-insensitively', async () => {
+    const result = await getPopCoordinates('DC12', 'Ashburn (DC12), VA, United States');
+    expect(result).toEqual({
+      latitude: 39.0438,
+      longitude: -77.4874,
+    });
+  });
+
+  it('should return null when site code not found and no geocoder provided', async () => {
+    const result = await getPopCoordinates('unknown', 'Unknown City, Country');
+    expect(result).toBeNull();
+  });
+
+  it('should return null when site code is null and no geocoder provided', async () => {
+    const result = await getPopCoordinates(null, 'Some City, Country');
+    expect(result).toBeNull();
+  });
+
+  it('should use geocoder fallback when site code not in static map', async () => {
+    const mockGeocoder = jest.fn().mockResolvedValue({
+      latitude: 10.0,
+      longitude: 20.0,
+    });
+
+    const result = await getPopCoordinates('unknown', 'Test City, Test Country', mockGeocoder);
+    expect(result).toEqual({
+      latitude: 10.0,
+      longitude: 20.0,
+    });
+    expect(mockGeocoder).toHaveBeenCalledWith('Test City, Test Country');
+  });
+
+  it('should use geocoder fallback when site code is null', async () => {
+    const mockGeocoder = jest.fn().mockResolvedValue({
+      latitude: 30.0,
+      longitude: 40.0,
+    });
+
+    const result = await getPopCoordinates(null, 'Another City, Country', mockGeocoder);
+    expect(result).toEqual({
+      latitude: 30.0,
+      longitude: 40.0,
+    });
+    expect(mockGeocoder).toHaveBeenCalledWith('Another City, Country');
+  });
+
+  it('should not use geocoder when site code found in static map', async () => {
+    const mockGeocoder = jest.fn();
+
+    const result = await getPopCoordinates('dc12', 'Ashburn (dc12)', mockGeocoder);
+    expect(result).toEqual({
+      latitude: 39.0438,
+      longitude: -77.4874,
+    });
+    expect(mockGeocoder).not.toHaveBeenCalled();
+  });
+
+  it('should return null when geocoder returns null', async () => {
+    const mockGeocoder = jest.fn().mockResolvedValue(null);
+
+    const result = await getPopCoordinates('unknown', 'Unknown City', mockGeocoder);
+    expect(result).toBeNull();
+  });
+
+  it('should handle geocoder with city, region, and country', async () => {
+    const mockGeocoder = jest.fn().mockResolvedValue({
+      latitude: 50.0,
+      longitude: 60.0,
+    });
+
+    const result = await getPopCoordinates(
+      'unknown',
+      'Ashburn (unknown), VA, United States',
+      mockGeocoder,
+    );
+    expect(result).toEqual({
+      latitude: 50.0,
+      longitude: 60.0,
+    });
+    expect(mockGeocoder).toHaveBeenCalledWith('Ashburn, VA, United States');
+  });
+});
+
+describe('formatCoordinates', () => {
+  it('should format positive latitude and longitude', () => {
+    const coords: Coordinates = { latitude: 39.0438, longitude: 8.6821 };
+    const result = formatCoordinates(coords);
+    expect(result).toBe('39.0438°N, 8.6821°E');
+  });
+
+  it('should format negative latitude (South)', () => {
+    const coords: Coordinates = { latitude: -33.8688, longitude: 151.2093 };
+    const result = formatCoordinates(coords);
+    expect(result).toBe('33.8688°S, 151.2093°E');
+  });
+
+  it('should format negative longitude (West)', () => {
+    const coords: Coordinates = { latitude: 39.0438, longitude: -77.4874 };
+    const result = formatCoordinates(coords);
+    expect(result).toBe('39.0438°N, 77.4874°W');
+  });
+
+  it('should format both negative coordinates', () => {
+    const coords: Coordinates = { latitude: -23.5505, longitude: -46.6333 };
+    const result = formatCoordinates(coords);
+    expect(result).toBe('23.5505°S, 46.6333°W');
+  });
+
+  it('should return N/A for null coordinates', () => {
+    const result = formatCoordinates(null);
+    expect(result).toBe('N/A');
+  });
+
+  it('should handle zero coordinates', () => {
+    const coords: Coordinates = { latitude: 0, longitude: 0 };
+    const result = formatCoordinates(coords);
+    expect(result).toBe('0.0000°N, 0.0000°E');
+  });
+
+  it('should format to 4 decimal places', () => {
+    const coords: Coordinates = { latitude: 39.04381234, longitude: -77.48741234 };
+    const result = formatCoordinates(coords);
+    expect(result).toBe('39.0438°N, 77.4874°W');
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for `geocoder.ts` and `popCoordinates.ts` modules
- Fix CI coverage threshold failure (was 18.79%, now 20.84%)
- Both new modules now have 100% test coverage

## Test plan
- [x] All unit tests pass locally (314 tests)
- [x] Coverage threshold met (20.84% > 19%)
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)