### PR TITLE
feat: rebrand voltstack to app stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The extension supports 40+ F5 XC resource types organized by category:
 - **Load Balancing**: HTTP/TCP/UDP Load Balancers, Origin Pools, Health Checks
 - **Security**: App Firewalls, Service Policies, Rate Limiters, WAF Exclusions
 - **Networking**: Virtual Networks, Network Connectors, Network Policies
-- **Sites**: AWS VPC, Azure VNET, GCP VPC, Voltstack, SecureMesh
+- **Sites**: AWS VPC, Azure VNET, GCP VPC, App Stack, SecureMesh
 - **DNS**: DNS Zones, DNS Load Balancers, DNS LB Pools
 - **IAM**: Namespaces, Users, Roles, API Credentials
 - **Observability**: Alert Policies, Alert Receivers, Log Receivers

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "f5",
     "distributed cloud",
     "f5xc",
-    "volterra",
+    "xc",
     "kubernetes",
     "load balancer",
     "waf",

--- a/scripts/generate-resource-types.ts
+++ b/scripts/generate-resource-types.ts
@@ -20,6 +20,11 @@ const RESOURCE_TYPES_OUTPUT = path.join(GENERATED_DIR, 'resourceTypesBase.ts');
 const CONSTANTS_OUTPUT = path.join(GENERATED_DIR, 'constants.ts');
 const INDEX_OUTPUT = path.join(GENERATED_DIR, 'index.ts');
 const SCOPE_OVERRIDES_PATH = path.join(__dirname, 'generators', 'namespace-scope-overrides.json');
+const DISPLAY_NAME_OVERRIDES_PATH = path.join(
+  __dirname,
+  'generators',
+  'display-name-overrides.json',
+);
 
 /**
  * Generate the barrel export file for the generated module
@@ -97,9 +102,14 @@ function main(): void {
     process.exit(1);
   }
 
-  // Generate resource types from specs (with namespace scope overrides)
+  // Generate resource types from specs (with namespace scope and display name overrides)
   console.log('Phase 1: Generating resource types from OpenAPI specs...');
-  const specs = generateResourceTypesFile(SPEC_DIR, RESOURCE_TYPES_OUTPUT, SCOPE_OVERRIDES_PATH);
+  const specs = generateResourceTypesFile(
+    SPEC_DIR,
+    RESOURCE_TYPES_OUTPUT,
+    SCOPE_OVERRIDES_PATH,
+    DISPLAY_NAME_OVERRIDES_PATH,
+  );
 
   if (specs.length === 0) {
     console.error('Error: No resource types were generated');

--- a/scripts/generators/display-name-overrides.json
+++ b/scripts/generators/display-name-overrides.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./display-name-overrides.schema.json",
+  "description": "Manual display name overrides for resources where the auto-generated name needs adjustment for branding or clarity",
+  "generatedNote": "These overrides are applied on top of the auto-generated display names from OpenAPI specs",
+  "overrides": {
+    "voltstack_site": {
+      "displayName": "App Stack Sites",
+      "reason": "Rebranding: 'Voltstack' is now 'App Stack' in F5 Distributed Cloud"
+    }
+  }
+}

--- a/scripts/generators/display-name-overrides.schema.json
+++ b/scripts/generators/display-name-overrides.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Display Name Overrides Schema",
+  "description": "Schema for display name overrides configuration",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of this configuration file"
+    },
+    "generatedNote": {
+      "type": "string",
+      "description": "Note about when these overrides are applied"
+    },
+    "overrides": {
+      "type": "object",
+      "description": "Map of resource keys to their display name overrides",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "description": "The display name to use instead of the auto-generated one"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Explanation for why this override exists"
+          }
+        },
+        "required": ["displayName"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["overrides"],
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- Replace 'volterra' keyword with 'xc' in package.json for VS Code Marketplace search
- Update README.md: 'Voltstack' → 'App Stack' in supported resource types
- Add display name override mechanism for generated resource types
- Override voltstack_site display name to 'App Stack Sites'

## Test plan
- [ ] Verify `npm run generate` applies the display name override
- [ ] Verify `npm run lint` passes
- [ ] Verify `npm run typecheck` passes
- [ ] Verify generated resourceTypesBase.ts shows "App Stack Sites" for voltstack_site

🤖 Generated with [Claude Code](https://claude.com/claude-code)