### PR TITLE
feat: add description normalization during code generation

### DIFF
--- a/scripts/generators/description-normalizer.ts
+++ b/scripts/generators/description-normalizer.ts
@@ -1,0 +1,117 @@
+/**
+ * Description normalizer for F5 XC resource types.
+ *
+ * This module provides functions to normalize descriptions from OpenAPI specs,
+ * replacing legacy Volterra terminology with current F5 Distributed Cloud branding.
+ *
+ * Note: This only affects user-facing descriptions, not API field names.
+ */
+
+/**
+ * Terminology replacement rules.
+ * Each rule maps a pattern to its replacement.
+ * Patterns are applied in order, so more specific patterns should come first.
+ */
+const TERMINOLOGY_REPLACEMENTS: Array<{ pattern: RegExp; replacement: string }> = [
+  // URL patterns - these should NOT be changed as they are actual URLs
+  // We explicitly skip console.ves.volterra.io URLs
+
+  // Product name replacements (case-insensitive)
+  { pattern: /\bVolterra's\b/gi, replacement: "F5 XC's" },
+  { pattern: /\bVolterra\b/g, replacement: 'F5 XC' },
+  { pattern: /\bvolterra\b/g, replacement: 'F5 XC' },
+
+  // Service references
+  { pattern: /\bvolterra service\b/gi, replacement: 'F5 XC service' },
+  { pattern: /\bvolterra edge cloud\b/gi, replacement: 'F5 XC edge cloud' },
+  { pattern: /\bvolterra software appliance\b/gi, replacement: 'F5 XC software appliance' },
+  { pattern: /\bvolterra site\b/gi, replacement: 'F5 XC site' },
+
+  // VoltConsole references
+  { pattern: /\bVoltConsole\b/g, replacement: 'F5 XC Console' },
+
+  // Regional Edge references
+  { pattern: /\bregional sites from volterra\b/gi, replacement: 'F5 XC Regional Edge sites' },
+];
+
+/**
+ * Patterns that should NOT be modified (API field names, URLs, etc.)
+ */
+const PRESERVE_PATTERNS: RegExp[] = [
+  // Actual console URLs
+  /console\.ves\.volterra\.io/g,
+  // API field names (these appear in descriptions as references)
+  /volterra_software_version/g,
+  /dns_volterra_managed/g,
+  /volterra_trusted_ca/g,
+];
+
+/**
+ * Normalize a description by replacing legacy terminology with current branding.
+ *
+ * @param description - The original description from OpenAPI spec
+ * @returns The normalized description with updated terminology
+ */
+export function normalizeDescription(description: string): string {
+  if (!description) {
+    return description;
+  }
+
+  // First, extract and preserve patterns that should not be modified
+  const preservedTokens: Map<string, string> = new Map();
+  let result = description;
+  let tokenIndex = 0;
+
+  for (const pattern of PRESERVE_PATTERNS) {
+    result = result.replace(pattern, (match) => {
+      const token = `__PRESERVED_${tokenIndex++}__`;
+      preservedTokens.set(token, match);
+      return token;
+    });
+  }
+
+  // Apply terminology replacements
+  for (const { pattern, replacement } of TERMINOLOGY_REPLACEMENTS) {
+    result = result.replace(pattern, replacement);
+  }
+
+  // Restore preserved patterns
+  for (const [token, original] of preservedTokens) {
+    result = result.replace(token, original);
+  }
+
+  return result;
+}
+
+/**
+ * Get a summary of terminology changes that would be applied to a description.
+ * Useful for debugging and verification.
+ *
+ * @param description - The original description
+ * @returns Object with original, normalized, and list of changes
+ */
+export function analyzeDescription(description: string): {
+  original: string;
+  normalized: string;
+  changes: Array<{ from: string; to: string }>;
+} {
+  const normalized = normalizeDescription(description);
+  const changes: Array<{ from: string; to: string }> = [];
+
+  // Simple diff to identify changes
+  if (description !== normalized) {
+    for (const { pattern, replacement } of TERMINOLOGY_REPLACEMENTS) {
+      const matches = description.match(pattern);
+      if (matches) {
+        for (const match of matches) {
+          // Only add if this change is actually in the result
+          if (description.includes(match) && !normalized.includes(match)) {
+            changes.push({ from: match, to: replacement });
+          }
+        }
+      }
+    }
+  }
+
+  return { original: description, normalized, changes };
+}

--- a/scripts/generators/menu-schema-generator.ts
+++ b/scripts/generators/menu-schema-generator.ts
@@ -15,6 +15,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { normalizeDescription } from './description-normalizer';
 
 /**
  * Manual override configuration structure
@@ -300,7 +301,7 @@ function parseSpec(filePath: string): ResourceAnalysis | null {
     return {
       resourceKey,
       displayName,
-      description: descriptionRaw.substring(0, 200),
+      description: normalizeDescription(descriptionRaw.substring(0, 200)),
       apiBase,
       schemaFile: filename,
       paths,

--- a/scripts/generators/spec-parser.ts
+++ b/scripts/generators/spec-parser.ts
@@ -7,6 +7,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { normalizeDescription } from './description-normalizer';
 
 /**
  * Namespace scope type - which namespaces can contain this resource
@@ -438,7 +439,7 @@ export function parseSpecFile(filePath: string): ParsedSpecInfo | null {
     resourceKey,
     apiPath,
     displayName,
-    description: spec.info?.description || '',
+    description: normalizeDescription(spec.info?.description || ''),
     apiBase: apiInfo.apiBase,
     serviceSegment: apiInfo.serviceSegment,
     fullApiPath,


### PR DESCRIPTION
## Summary
- Add description normalization module that replaces legacy Volterra terminology with current F5 XC branding during code generation
- Integrate normalizer into both spec-parser.ts (for resourceTypesBase.ts) and menu-schema-generator.ts (for menuSchema.json)
- Preserve actual console URLs and API field names that cannot be changed

## Changes
- **New file**: `scripts/generators/description-normalizer.ts` - Terminology replacement module
- **Modified**: `scripts/generators/spec-parser.ts` - Apply normalization to descriptions
- **Modified**: `scripts/generators/menu-schema-generator.ts` - Apply normalization to descriptions

## Terminology Replacements
| From | To |
|------|-----|
| Volterra | F5 XC |
| Volterra's | F5 XC's |
| volterra service | F5 XC service |
| volterra site | F5 XC site |
| VoltConsole | F5 XC Console |

## Preserved (not changed)
- `console.ves.volterra.io` URLs (actual F5 XC console domain)
- API field names: `volterra_software_version`, `dns_volterra_managed`, `volterra_trusted_ca`

## Test plan
- [x] Run `npm run generate` - generation completes successfully
- [x] Run `npm run typecheck` - no type errors
- [x] Run `npm run lint` - no lint errors
- [x] Verify "volterra" replaced with "F5 XC" in generated descriptions
- [x] Verify console URLs preserved
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)