### PR TITLE
fix: upgrade node.js from 20 to 22 in all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20]
+        node-version: [22]
 
     steps:
       - name: Checkout repository
@@ -131,7 +131,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - name: Install dependencies
@@ -170,7 +170,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Upgrade Node.js version from 20 to 22 in all GitHub Actions workflows
- Resolves EBADENGINE npm warnings from semantic-release packages

## Problem
The semantic-release packages (v25) require Node.js `^22.14.0 || >= 24.10.0`, but workflows were using Node.js 20, causing warnings:
```
npm warn EBADENGINE Unsupported engine {
  package: 'semantic-release@25.0.2',
  required: { node: '^22.14.0 || >= 24.10.0' },
  current: { node: 'v20.19.6', npm: '10.8.2' }
}
```

## Changes
| Workflow | Jobs Updated |
|----------|--------------|
| `ci.yml` | validate-generation, test (matrix), build, security |
| `release.yml` | publish-openvsx, publish-marketplace |

## Test plan
- [ ] CI passes on all platforms (ubuntu, macos, windows)
- [ ] No EBADENGINE warnings in npm install logs
- [ ] Build and package succeed with Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)