### PR TITLE
fix: update engines.vscode to match @types/vscode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/robinmordasiewicz/vscode-f5xc-tools"
   },
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.107.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
## Summary
- Update engines.vscode from ^1.85.0 to ^1.107.0 to match @types/vscode version
- Fixes vsce packaging validation error that occurred when @types/vscode version exceeded engines.vscode

## Test plan
- [x] Build passes (`npm run package`)
- [x] Extension packages successfully (`vsce package`)
- [x] Extension installs in VS Code (`code --install-extension`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)