### PR TITLE
feat: add delete namespace with rbac permission checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,12 @@
         "icon": "$(trash)"
       },
       {
+        "command": "f5xc.deleteNamespace",
+        "title": "Delete Namespace",
+        "category": "F5 XC",
+        "icon": "$(trash)"
+      },
+      {
         "command": "f5xc.apply",
         "title": "Apply",
         "category": "F5 XC",
@@ -345,6 +351,11 @@
           "command": "f5xc.delete",
           "when": "view == f5xc.explorer && viewItem =~ /resource:/",
           "group": "1_resource@4"
+        },
+        {
+          "command": "f5xc.deleteNamespace",
+          "when": "view == f5xc.explorer && viewItem == namespace:custom",
+          "group": "1_namespace@1"
         },
         {
           "command": "f5xc.diff",

--- a/src/test/unit/errors.test.ts
+++ b/src/test/unit/errors.test.ts
@@ -127,18 +127,52 @@ describe('F5XCApiError', () => {
     });
   });
 
+  describe('isUnauthorized', () => {
+    it('should return true for 401', () => {
+      const error = new F5XCApiError(401, 'Unauthorized');
+      expect(error.isUnauthorized).toBe(true);
+    });
+
+    it('should return false for 403', () => {
+      const error = new F5XCApiError(403, 'Forbidden');
+      expect(error.isUnauthorized).toBe(false);
+    });
+
+    it('should return false for other status codes', () => {
+      const error = new F5XCApiError(404, 'Not found');
+      expect(error.isUnauthorized).toBe(false);
+    });
+  });
+
+  describe('isForbidden', () => {
+    it('should return true for 403', () => {
+      const error = new F5XCApiError(403, 'Forbidden');
+      expect(error.isForbidden).toBe(true);
+    });
+
+    it('should return false for 401', () => {
+      const error = new F5XCApiError(401, 'Unauthorized');
+      expect(error.isForbidden).toBe(false);
+    });
+
+    it('should return false for other status codes', () => {
+      const error = new F5XCApiError(404, 'Not found');
+      expect(error.isForbidden).toBe(false);
+    });
+  });
+
   describe('userFriendlyMessage', () => {
-    it('should return auth message for 401', () => {
+    it('should return auth failed message for 401', () => {
       const error = new F5XCApiError(401, 'Unauthorized');
       expect(error.userFriendlyMessage).toBe(
-        'Authentication failed. Please check your credentials.',
+        'Authentication failed. Please check your credentials or re-authenticate.',
       );
     });
 
-    it('should return auth message for 403', () => {
+    it('should return permission denied message for 403', () => {
       const error = new F5XCApiError(403, 'Forbidden');
       expect(error.userFriendlyMessage).toBe(
-        'Authentication failed. Please check your credentials.',
+        'Permission denied. You do not have access to perform this operation.',
       );
     });
 

--- a/src/test/unit/treeTypes.test.ts
+++ b/src/test/unit/treeTypes.test.ts
@@ -9,6 +9,14 @@ describe('TreeItemContext', () => {
     expect(TreeItemContext.NAMESPACE).toBe('namespace');
   });
 
+  it('should have NAMESPACE_BUILTIN context', () => {
+    expect(TreeItemContext.NAMESPACE_BUILTIN).toBe('namespace:builtin');
+  });
+
+  it('should have NAMESPACE_CUSTOM context', () => {
+    expect(TreeItemContext.NAMESPACE_CUSTOM).toBe('namespace:custom');
+  });
+
   it('should have CATEGORY context', () => {
     expect(TreeItemContext.CATEGORY).toBe('category');
   });
@@ -26,9 +34,11 @@ describe('TreeItemContext', () => {
     const keys = Object.keys(TreeItemContext);
     expect(keys).toContain('NAMESPACE_GROUP');
     expect(keys).toContain('NAMESPACE');
+    expect(keys).toContain('NAMESPACE_BUILTIN');
+    expect(keys).toContain('NAMESPACE_CUSTOM');
     expect(keys).toContain('CATEGORY');
     expect(keys).toContain('RESOURCE_TYPE');
     expect(keys).toContain('RESOURCE');
-    expect(keys).toHaveLength(5);
+    expect(keys).toHaveLength(7);
   });
 });

--- a/src/tree/treeTypes.ts
+++ b/src/tree/treeTypes.ts
@@ -18,6 +18,8 @@ export interface F5XCTreeItem {
 export const TreeItemContext = {
   NAMESPACE_GROUP: 'namespaceGroup',
   NAMESPACE: 'namespace',
+  NAMESPACE_BUILTIN: 'namespace:builtin',
+  NAMESPACE_CUSTOM: 'namespace:custom',
   CATEGORY: 'category',
   RESOURCE_TYPE: 'resourceType',
   RESOURCE: 'resource',
@@ -29,6 +31,7 @@ export const TreeItemContext = {
 export interface NamespaceNodeData {
   name: string;
   profileName: string;
+  isBuiltIn?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add "Delete Namespace" context menu for custom namespaces only
- Implement RBAC permission pre-checking before showing confirmation dialog
- Add `checkApiAccess()` method to verify user permissions via evaluate-api-access API
- Add `cascadeDeleteNamespace()` method for namespace cascade deletion
- Differentiate built-in vs custom namespaces using context values
- Improve error handling to distinguish 401 (auth failed) vs 403 (permission denied)
- Update existing delete command with RBAC pre-checking
- Add comprehensive unit tests for new functionality

## Test plan
- [x] Unit tests pass (322 tests)
- [x] Lint and typecheck pass
- [x] "Delete Namespace" appears only for custom namespaces
- [x] "Delete Namespace" hidden for built-in namespaces (system, shared, default)
- [ ] RBAC check runs before confirmation dialog
- [ ] Permission denied shows clear error message
- [ ] Successful delete removes namespace and refreshes tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)