### PR TITLE
feat: enhance namespace describe with metadata fields

### DIFF
--- a/src/providers/f5xcDescribeProvider.ts
+++ b/src/providers/f5xcDescribeProvider.ts
@@ -1200,11 +1200,34 @@ export class F5XCDescribeProvider {
     if (metadata?.description) {
       metadataFields.push({ key: 'Description', value: String(metadata.description) });
     }
+    // Creator information from system metadata
+    if (systemMetadata?.creator) {
+      metadataFields.push({ key: 'Creator', value: String(systemMetadata.creator) });
+    }
+    // Creation timestamp
+    const createTime = this.formatTimestamp(
+      systemMetadata?.creation_timestamp as string | undefined,
+    );
+    if (createTime) {
+      metadataFields.push({ key: 'Created', value: createTime });
+    }
     const modTime = this.formatTimestamp(
       systemMetadata?.modification_timestamp as string | undefined,
     );
     if (modTime) {
       metadataFields.push({ key: 'Last Modified', value: modTime });
+    }
+    // Unique identifier
+    if (systemMetadata?.uid) {
+      metadataFields.push({ key: 'UID', value: String(systemMetadata.uid) });
+    }
+    // Labels (key-value pairs for organization)
+    if (metadata?.labels && Object.keys(metadata.labels as object).length > 0) {
+      const labels = metadata.labels as Record<string, string>;
+      const labelStr = Object.entries(labels)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(', ');
+      metadataFields.push({ key: 'Labels', value: labelStr });
     }
     sections.push({ id: 'metadata', title: 'Metadata', fields: metadataFields });
 


### PR DESCRIPTION
## Summary
Enhance the namespace describe view with additional metadata fields for better visibility into namespace ownership, lifecycle, and organization.

## Changes
- **Creator**: Display who created the namespace
- **Created**: Show creation timestamp  
- **UID**: Display unique identifier for debugging/API operations
- **Labels**: Show key-value labels for organization

## Metadata Display Order
1. Name
2. Description
3. Creator ✨ (new)
4. Created ✨ (new)
5. Last Modified
6. UID ✨ (new)
7. Labels ✨ (new - only if labels exist)

## Test Plan
1. Open namespace describe view
2. Verify new fields appear in metadata section
3. Verify labels display in `key=value` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)