### PR TITLE
feat: implement xdg-compliant shared authentication system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-f5xc-tools",
-  "version": "0.1.30",
+  "version": "1.0.2512312039",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-f5xc-tools",
-      "version": "0.1.30",
+      "version": "1.0.2512312039",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -134,7 +134,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1926,7 +1925,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3014,7 +3012,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3109,7 +3106,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -3332,6 +3328,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@vscode/test-cli/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/@vscode/test-cli/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -3391,6 +3412,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/@vscode/test-electron": {
@@ -3638,7 +3672,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3698,7 +3731,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4057,7 +4089,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4344,31 +4375,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -4915,7 +4921,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5506,7 +5511,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7042,7 +7046,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8659,7 +8662,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11709,7 +11711,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12864,19 +12865,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -13113,7 +13101,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -14538,7 +14525,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14738,7 +14724,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14986,7 +14971,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -15036,7 +15020,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -576,6 +576,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.2.0",
     "@commitlint/config-conventional": "^20.2.0",
+    "@eslint/js": "^9.17.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/glob": "^8.1.0",
@@ -584,16 +585,14 @@
     "@types/node": "22.x",
     "@types/node-forge": "^1.3.11",
     "@types/vscode": "^1.107.0",
-    "@eslint/js": "^9.17.0",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.3.8",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^10.0.1",
-    "globals": "^16.0.0",
-    "typescript-eslint": "^8.19.0",
     "glob": "^13.0.0",
+    "globals": "^16.0.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "lint-staged": "^16.2.0",
@@ -604,6 +603,7 @@
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.1",
     "typescript": "^5.3.3",
+    "typescript-eslint": "^8.19.0",
     "webpack": "^5.89.0",
     "webpack-cli": "^6.0.0"
   }

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -5,7 +5,7 @@ import * as https from 'https';
  */
 export interface AuthProvider {
   /** The type of authentication */
-  readonly type: 'token' | 'p12';
+  readonly type: 'token' | 'cert';
 
   /** Get HTTP headers required for authentication */
   getHeaders(): Record<string, string>;
@@ -25,16 +25,23 @@ export interface AuthProvider {
  */
 export interface TokenAuthConfig {
   apiUrl: string;
-  token: string;
+  apiToken: string;
 }
 
 /**
- * Configuration for P12 certificate-based authentication
+ * Configuration for certificate-based authentication
+ * Supports two methods:
+ * 1. P12 Bundle: p12Bundle path (password from F5XC_P12_PASSWORD env var)
+ * 2. Cert + Key: Direct PEM file paths
  */
-export interface P12AuthConfig {
+export interface CertAuthConfig {
   apiUrl: string;
-  p12Path: string;
-  p12Password: string;
+  /** P12 bundle file path */
+  p12Bundle?: string;
+  /** TLS certificate PEM file path */
+  cert?: string;
+  /** TLS private key PEM file path */
+  key?: string;
 }
 
 /**
@@ -42,7 +49,7 @@ export interface P12AuthConfig {
  */
 export type AuthConfig =
   | { type: 'token'; config: TokenAuthConfig }
-  | { type: 'p12'; config: P12AuthConfig };
+  | { type: 'cert'; config: CertAuthConfig };
 
 export { TokenAuthProvider } from './tokenAuth';
-export { P12AuthProvider } from './p12Auth';
+export { CertAuthProvider } from './certAuth';

--- a/src/api/auth/tokenAuth.ts
+++ b/src/api/auth/tokenAuth.ts
@@ -9,17 +9,17 @@ import { API_ENDPOINTS } from '../../generated/constants';
 export class TokenAuthProvider implements AuthProvider {
   readonly type = 'token' as const;
   private readonly apiUrl: string;
-  private readonly token: string;
+  private readonly apiToken: string;
   private readonly logger = getLogger();
 
   constructor(config: TokenAuthConfig) {
     this.apiUrl = config.apiUrl;
-    this.token = config.token;
+    this.apiToken = config.apiToken;
   }
 
   getHeaders(): Record<string, string> {
     return {
-      Authorization: `APIToken ${this.token}`,
+      Authorization: `APIToken ${this.apiToken}`,
       'Content-Type': 'application/json',
       Accept: 'application/json',
     };

--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -64,7 +64,7 @@ export function registerCrudCommands(
     vscode.commands.registerCommand('f5xc.get', async (node: ResourceNode) => {
       await withErrorHandling(async () => {
         const data = node.getData();
-        const profile = profileManager.getProfile(data.profileName);
+        const profile = await profileManager.getProfile(data.profileName);
 
         if (!profile) {
           showWarning(`Profile "${data.profileName}" not found`);
@@ -150,7 +150,7 @@ export function registerCrudCommands(
             };
           }
 
-          const profile = profileManager.getProfile(data.profileName);
+          const profile = await profileManager.getProfile(data.profileName);
 
           if (!profile) {
             showWarning(`Profile "${data.profileName}" not found`);
@@ -298,7 +298,7 @@ export function registerCrudCommands(
         }
 
         // Get active profile
-        const activeProfile = profileManager.getActiveProfile();
+        const activeProfile = await profileManager.getActiveProfile();
         if (!activeProfile) {
           showWarning('No active profile. Configure a profile first.');
           return;
@@ -680,7 +680,7 @@ export function registerCrudCommands(
             return;
           }
 
-          const activeProfile = profileManager.getActiveProfile();
+          const activeProfile = await profileManager.getActiveProfile();
           if (!activeProfile) {
             showWarning('No active profile');
             return;
@@ -768,7 +768,7 @@ export function registerCrudCommands(
   context.subscriptions.push(
     vscode.commands.registerCommand('f5xc.openInBrowser', async (node: ResourceNode) => {
       const data = node.getData();
-      const profile = profileManager.getProfile(data.profileName);
+      const profile = await profileManager.getProfile(data.profileName);
 
       if (!profile) {
         showWarning(`Profile "${data.profileName}" not found`);

--- a/src/commands/diagram.ts
+++ b/src/commands/diagram.ts
@@ -27,7 +27,7 @@ export function registerDiagramCommands(
     vscode.commands.registerCommand('f5xc.diagram', async (node: ResourceNode) => {
       await withErrorHandling(async () => {
         const data = node.getData();
-        const profile = profileManager.getProfile(data.profileName);
+        const profile = await profileManager.getProfile(data.profileName);
 
         if (!profile) {
           showWarning(`Profile "${data.profileName}" not found`);

--- a/src/commands/observability.ts
+++ b/src/commands/observability.ts
@@ -63,7 +63,7 @@ export function registerObservabilityCommands(
     vscode.commands.registerCommand('f5xc.viewLogs', async (node: ResourceNode) => {
       await withErrorHandling(async () => {
         const data = node.getData();
-        const profile = profileManager.getProfile(data.profileName);
+        const profile = await profileManager.getProfile(data.profileName);
 
         if (!profile) {
           showWarning(`Profile "${data.profileName}" not found`);
@@ -140,7 +140,7 @@ export function registerObservabilityCommands(
     vscode.commands.registerCommand('f5xc.viewMetrics', async (node: ResourceNode) => {
       await withErrorHandling(async () => {
         const data = node.getData();
-        const profile = profileManager.getProfile(data.profileName);
+        const profile = await profileManager.getProfile(data.profileName);
 
         if (!profile) {
           showWarning(`Profile "${data.profileName}" not found`);

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,8 +1,13 @@
 import * as vscode from 'vscode';
-import { ProfileManager, F5XCProfile } from '../config/profiles';
+import { ProfileManager, Profile } from '../config/profiles';
 import { ProfilesProvider, ProfileTreeItem } from '../tree/profilesProvider';
 import { F5XCExplorerProvider } from '../tree/f5xcExplorer';
 import { withErrorHandling, showInfo, showWarning } from '../utils/errors';
+
+/**
+ * Auth type selection options
+ */
+type AuthType = 'apiToken' | 'p12Bundle' | 'certKey';
 
 /**
  * Register profile management commands
@@ -28,6 +33,9 @@ export function registerProfileCommands(
             }
             if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
               return 'Profile name can only contain letters, numbers, underscores, and hyphens';
+            }
+            if (value.length > 64) {
+              return 'Profile name must be 64 characters or less';
             }
             return null;
           },
@@ -61,17 +69,23 @@ export function registerProfileCommands(
         }
 
         // Step 3: Authentication type
-        const authType = await vscode.window.showQuickPick(
+        const authTypeChoice = await vscode.window.showQuickPick(
           [
             {
               label: 'API Token',
               description: 'Use an API token for authentication',
-              value: 'token' as const,
+              value: 'apiToken' as AuthType,
             },
             {
-              label: 'P12 Certificate',
-              description: 'Use a P12 certificate file for authentication',
-              value: 'p12' as const,
+              label: 'P12 Certificate Bundle',
+              description:
+                'Use a P12/PFX certificate file (password from F5XC_P12_PASSWORD env var)',
+              value: 'p12Bundle' as AuthType,
+            },
+            {
+              label: 'Certificate + Key Files',
+              description: 'Use separate PEM certificate and key files',
+              value: 'certKey' as AuthType,
             },
           ],
           {
@@ -80,16 +94,19 @@ export function registerProfileCommands(
           },
         );
 
-        if (!authType) {
+        if (!authTypeChoice) {
           return;
         }
 
-        const credentials: { token?: string; p12Password?: string } = {};
-        let p12Path: string | undefined;
+        // Build profile based on auth type
+        const profile: Profile = {
+          name,
+          apiUrl,
+        };
 
-        if (authType.value === 'token') {
+        if (authTypeChoice.value === 'apiToken') {
           // Step 4a: API Token
-          const token = await vscode.window.showInputBox({
+          const apiToken = await vscode.window.showInputBox({
             prompt: 'Enter your API token',
             password: true,
             placeHolder: 'Your API token',
@@ -102,12 +119,12 @@ export function registerProfileCommands(
             },
           });
 
-          if (!token) {
+          if (!apiToken) {
             return;
           }
 
-          credentials.token = token;
-        } else {
+          profile.apiToken = apiToken;
+        } else if (authTypeChoice.value === 'p12Bundle') {
           // Step 4b: P12 file path
           const fileUris = await vscode.window.showOpenDialog({
             canSelectFiles: true,
@@ -123,39 +140,59 @@ export function registerProfileCommands(
             return;
           }
 
-          p12Path = fileUris[0]?.fsPath;
+          profile.p12Bundle = fileUris[0]?.fsPath;
 
-          // Step 5: P12 password
-          const p12Password = await vscode.window.showInputBox({
-            prompt: 'Enter P12 certificate password',
-            password: true,
-            placeHolder: 'Certificate password',
-            ignoreFocusOut: true,
-            validateInput: (value) => {
-              if (!value) {
-                return 'Password is required';
-              }
-              return null;
+          // Inform user about password environment variable
+          showInfo('P12 password should be set via the F5XC_P12_PASSWORD environment variable.');
+        } else if (authTypeChoice.value === 'certKey') {
+          // Step 4c: Certificate file
+          const certUris = await vscode.window.showOpenDialog({
+            canSelectFiles: true,
+            canSelectFolders: false,
+            canSelectMany: false,
+            filters: {
+              'PEM Certificate': ['pem', 'crt', 'cer'],
             },
+            title: 'Select Certificate File (PEM format)',
           });
 
-          if (!p12Password) {
+          if (!certUris || certUris.length === 0) {
             return;
           }
 
-          credentials.p12Password = p12Password;
+          profile.cert = certUris[0]?.fsPath;
+
+          // Step 4d: Key file
+          const keyUris = await vscode.window.showOpenDialog({
+            canSelectFiles: true,
+            canSelectFolders: false,
+            canSelectMany: false,
+            filters: {
+              'PEM Private Key': ['pem', 'key'],
+            },
+            title: 'Select Private Key File (PEM format)',
+          });
+
+          if (!keyUris || keyUris.length === 0) {
+            return;
+          }
+
+          profile.key = keyUris[0]?.fsPath;
         }
 
-        // Create profile
-        const profile: F5XCProfile = {
-          name,
-          apiUrl,
-          authType: authType.value,
-          p12Path,
-        };
+        // Step 5: Optional default namespace
+        const defaultNamespace = await vscode.window.showInputBox({
+          prompt: 'Enter default namespace (optional)',
+          placeHolder: 'system',
+          ignoreFocusOut: true,
+        });
+
+        if (defaultNamespace && defaultNamespace.trim().length > 0) {
+          profile.defaultNamespace = defaultNamespace.trim();
+        }
 
         // Add profile
-        await profileManager.addProfile(profile, credentials);
+        await profileManager.addProfile(profile);
 
         // Validate credentials
         const validating = await vscode.window.withProgress(
@@ -193,7 +230,7 @@ export function registerProfileCommands(
           profileName = node.getProfile().name;
         } else {
           // Prompt user to select profile
-          const profiles = profileManager.getProfiles();
+          const profiles = await profileManager.getProfiles();
           if (profiles.length === 0) {
             showWarning('No profiles configured');
             return;
@@ -203,7 +240,7 @@ export function registerProfileCommands(
             profiles.map((p) => ({
               label: p.name,
               description: p.apiUrl,
-              detail: `Auth: ${p.authType}`,
+              detail: getAuthTypeDescription(p),
             })),
             { placeHolder: 'Select profile to edit', ignoreFocusOut: true },
           );
@@ -215,30 +252,44 @@ export function registerProfileCommands(
           profileName = selected.label;
         }
 
-        const profile = profileManager.getProfile(profileName);
+        const profile = await profileManager.getProfile(profileName);
         if (!profile) {
           showWarning(`Profile "${profileName}" not found`);
           return;
         }
 
-        // Show options for what to edit
-        const editOption = await vscode.window.showQuickPick(
-          [
-            { label: 'API URL', description: `Current: ${profile.apiUrl}` },
-            { label: 'Credentials', description: 'Update authentication credentials' },
-            ...(profile.authType === 'p12'
-              ? [{ label: 'P12 File', description: `Current: ${profile.p12Path || 'Not set'}` }]
-              : []),
-          ],
-          { placeHolder: 'What would you like to edit?', ignoreFocusOut: true },
-        );
+        // Build edit options based on current profile
+        const editOptions: { label: string; description: string }[] = [
+          { label: 'API URL', description: `Current: ${profile.apiUrl}` },
+          {
+            label: 'Default Namespace',
+            description: `Current: ${profile.defaultNamespace || 'Not set'}`,
+          },
+        ];
+
+        if (profile.apiToken) {
+          editOptions.push({ label: 'API Token', description: 'Update API token' });
+        }
+        if (profile.p12Bundle) {
+          editOptions.push({ label: 'P12 Bundle', description: `Current: ${profile.p12Bundle}` });
+        }
+        if (profile.cert) {
+          editOptions.push({ label: 'Certificate', description: `Current: ${profile.cert}` });
+        }
+        if (profile.key) {
+          editOptions.push({ label: 'Private Key', description: `Current: ${profile.key}` });
+        }
+
+        const editOption = await vscode.window.showQuickPick(editOptions, {
+          placeHolder: 'What would you like to edit?',
+          ignoreFocusOut: true,
+        });
 
         if (!editOption) {
           return;
         }
 
-        const updates: Partial<F5XCProfile> = {};
-        const credentials: { token?: string; p12Password?: string } = {};
+        const updates: Partial<Profile> = {};
 
         switch (editOption.label) {
           case 'API URL': {
@@ -262,38 +313,38 @@ export function registerProfileCommands(
             break;
           }
 
-          case 'Credentials': {
-            if (profile.authType === 'token') {
-              const newToken = await vscode.window.showInputBox({
-                prompt: 'Enter new API token',
-                password: true,
-                placeHolder: 'New API token',
-                ignoreFocusOut: true,
-              });
+          case 'Default Namespace': {
+            const newNamespace = await vscode.window.showInputBox({
+              prompt: 'Enter new default namespace (leave empty to clear)',
+              value: profile.defaultNamespace || '',
+              ignoreFocusOut: true,
+            });
 
-              if (!newToken) {
-                return;
-              }
-
-              credentials.token = newToken;
-            } else {
-              const newPassword = await vscode.window.showInputBox({
-                prompt: 'Enter new P12 password',
-                password: true,
-                placeHolder: 'New P12 password',
-                ignoreFocusOut: true,
-              });
-
-              if (!newPassword) {
-                return;
-              }
-
-              credentials.p12Password = newPassword;
+            if (newNamespace === undefined) {
+              return;
             }
+
+            updates.defaultNamespace = newNamespace.trim() || undefined;
             break;
           }
 
-          case 'P12 File': {
+          case 'API Token': {
+            const newToken = await vscode.window.showInputBox({
+              prompt: 'Enter new API token',
+              password: true,
+              placeHolder: 'New API token',
+              ignoreFocusOut: true,
+            });
+
+            if (!newToken) {
+              return;
+            }
+
+            updates.apiToken = newToken;
+            break;
+          }
+
+          case 'P12 Bundle': {
             const fileUris = await vscode.window.showOpenDialog({
               canSelectFiles: true,
               canSelectFolders: false,
@@ -308,17 +359,51 @@ export function registerProfileCommands(
               return;
             }
 
-            updates.p12Path = fileUris[0]?.fsPath;
+            updates.p12Bundle = fileUris[0]?.fsPath;
+            break;
+          }
+
+          case 'Certificate': {
+            const certUris = await vscode.window.showOpenDialog({
+              canSelectFiles: true,
+              canSelectFolders: false,
+              canSelectMany: false,
+              filters: {
+                'PEM Certificate': ['pem', 'crt', 'cer'],
+              },
+              title: 'Select new Certificate File',
+            });
+
+            if (!certUris || certUris.length === 0) {
+              return;
+            }
+
+            updates.cert = certUris[0]?.fsPath;
+            break;
+          }
+
+          case 'Private Key': {
+            const keyUris = await vscode.window.showOpenDialog({
+              canSelectFiles: true,
+              canSelectFolders: false,
+              canSelectMany: false,
+              filters: {
+                'PEM Private Key': ['pem', 'key'],
+              },
+              title: 'Select new Private Key File',
+            });
+
+            if (!keyUris || keyUris.length === 0) {
+              return;
+            }
+
+            updates.key = keyUris[0]?.fsPath;
             break;
           }
         }
 
         // Apply updates
-        await profileManager.updateProfile(
-          profileName,
-          updates,
-          Object.keys(credentials).length > 0 ? credentials : undefined,
-        );
+        await profileManager.updateProfile(profileName, updates);
 
         showInfo(`Profile "${profileName}" updated`);
         profilesProvider.refresh();
@@ -337,7 +422,7 @@ export function registerProfileCommands(
           profileName = node.getProfile().name;
         } else {
           // Prompt user to select profile
-          const profiles = profileManager.getProfiles();
+          const profiles = await profileManager.getProfiles();
           if (profiles.length === 0) {
             showWarning('No profiles configured');
             return;
@@ -387,7 +472,9 @@ export function registerProfileCommands(
           profileName = node.getProfile().name;
         } else {
           // Prompt user to select profile
-          const profiles = profileManager.getProfiles();
+          const profiles = await profileManager.getProfiles();
+          const activeName = await profileManager.getActiveProfileName();
+
           if (profiles.length === 0) {
             showWarning('No profiles configured');
             return;
@@ -396,7 +483,7 @@ export function registerProfileCommands(
           const selected = await vscode.window.showQuickPick(
             profiles.map((p) => ({
               label: p.name,
-              description: p.isActive ? '(active)' : '',
+              description: p.name === activeName ? '(active)' : '',
               detail: p.apiUrl,
             })),
             { placeHolder: 'Select profile to activate', ignoreFocusOut: true },
@@ -416,4 +503,20 @@ export function registerProfileCommands(
       }, 'Set active profile');
     }),
   );
+}
+
+/**
+ * Get a human-readable description of the profile's auth type
+ */
+function getAuthTypeDescription(profile: Profile): string {
+  if (profile.apiToken) {
+    return 'Auth: API Token';
+  }
+  if (profile.p12Bundle) {
+    return 'Auth: P12 Certificate';
+  }
+  if (profile.cert && profile.key) {
+    return 'Auth: Certificate + Key';
+  }
+  return 'Auth: Not configured';
 }

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,0 +1,75 @@
+/**
+ * XDG Base Directory paths for cross-tool compatibility with f5xc-xcsh and f5xc-api-mcp
+ *
+ * Structure:
+ *   ~/.config/xcsh/
+ *   ├── active_profile     # Plain text: active profile name
+ *   └── profiles/          # Profile JSON files
+ *       ├── profile-1.json
+ *       └── profile-2.json
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+
+/** Application name for XDG directories - matches f5xc-xcsh */
+const APP_NAME = 'xcsh';
+
+/** File permissions: owner read/write only */
+export const FILE_MODE = 0o600;
+
+/** Directory permissions: owner read/write/execute only */
+export const DIR_MODE = 0o700;
+
+/**
+ * Get the XDG config directory for xcsh
+ * - Windows: %APPDATA%\xcsh
+ * - Unix: $XDG_CONFIG_HOME/xcsh or ~/.config/xcsh
+ */
+export function getConfigDir(): string {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData) {
+      return path.join(appData, APP_NAME);
+    }
+    return path.join(os.homedir(), APP_NAME);
+  }
+
+  const xdgConfig = process.env.XDG_CONFIG_HOME;
+  if (xdgConfig) {
+    return path.join(xdgConfig, APP_NAME);
+  }
+  return path.join(os.homedir(), '.config', APP_NAME);
+}
+
+/**
+ * Get the profiles directory
+ */
+export function getProfilesDir(): string {
+  return path.join(getConfigDir(), 'profiles');
+}
+
+/**
+ * Get the path to the active profile file
+ */
+export function getActiveProfilePath(): string {
+  return path.join(getConfigDir(), 'active_profile');
+}
+
+/**
+ * Get the path to a specific profile JSON file
+ */
+export function getProfilePath(name: string): string {
+  return path.join(getProfilesDir(), `${name}.json`);
+}
+
+/**
+ * Validate profile name - must be alphanumeric, dash, underscore only
+ * Max 64 characters (matches f5xc-xcsh)
+ */
+export function isValidProfileName(name: string): boolean {
+  if (!name || name.length > 64) {
+    return false;
+  }
+  return /^[a-zA-Z0-9_-]+$/.test(name);
+}

--- a/src/config/xdgProfiles.ts
+++ b/src/config/xdgProfiles.ts
@@ -1,0 +1,308 @@
+/**
+ * XDG-compliant ProfileManager for cross-tool compatibility
+ * Compatible with f5xc-xcsh and f5xc-api-mcp
+ *
+ * Profiles stored at: ~/.config/xcsh/profiles/{name}.json
+ * Active profile at: ~/.config/xcsh/active_profile
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  getConfigDir,
+  getProfilesDir,
+  getActiveProfilePath,
+  getProfilePath,
+  isValidProfileName,
+  FILE_MODE,
+  DIR_MODE,
+} from './paths';
+
+/**
+ * Profile interface - must match f5xc-xcsh exactly
+ */
+export interface Profile {
+  name: string;
+  apiUrl: string;
+  apiToken?: string;
+  p12Bundle?: string;
+  cert?: string;
+  key?: string;
+  defaultNamespace?: string;
+}
+
+/**
+ * XDG-compliant ProfileManager
+ * File-based storage with atomic writes and proper permissions
+ */
+export class XDGProfileManager {
+  /**
+   * Ensure config directories exist with proper permissions
+   */
+  async ensureDirectories(): Promise<void> {
+    const configDir = getConfigDir();
+    const profilesDir = getProfilesDir();
+
+    for (const dir of [configDir, profilesDir]) {
+      if (!fs.existsSync(dir)) {
+        await fs.promises.mkdir(dir, { recursive: true, mode: DIR_MODE });
+      }
+    }
+  }
+
+  /**
+   * List all profiles
+   */
+  async list(): Promise<Profile[]> {
+    const profilesDir = getProfilesDir();
+
+    if (!fs.existsSync(profilesDir)) {
+      return [];
+    }
+
+    const files = await fs.promises.readdir(profilesDir);
+    const profiles: Profile[] = [];
+
+    for (const file of files) {
+      if (!file.endsWith('.json')) {
+        continue;
+      }
+
+      const name = path.basename(file, '.json');
+      const profile = await this.get(name);
+      if (profile) {
+        profiles.push(profile);
+      }
+    }
+
+    return profiles;
+  }
+
+  /**
+   * Get a profile by name
+   */
+  async get(name: string): Promise<Profile | null> {
+    if (!isValidProfileName(name)) {
+      return null;
+    }
+
+    const profilePath = getProfilePath(name);
+
+    if (!fs.existsSync(profilePath)) {
+      return null;
+    }
+
+    try {
+      const content = await fs.promises.readFile(profilePath, 'utf-8');
+      const profile = JSON.parse(content) as Profile;
+
+      // Ensure name matches filename
+      profile.name = name;
+      return profile;
+    } catch {
+      // Malformed JSON - skip profile, don't crash
+      console.warn(`Skipping malformed profile: ${name}`);
+      return null;
+    }
+  }
+
+  /**
+   * Save a profile (create or update)
+   * Uses atomic write: temp file + rename
+   */
+  async save(profile: Profile): Promise<void> {
+    if (!isValidProfileName(profile.name)) {
+      throw new Error(
+        `Invalid profile name: ${profile.name}. Must be alphanumeric, dash, or underscore only (max 64 chars).`,
+      );
+    }
+
+    await this.ensureDirectories();
+
+    const profilePath = getProfilePath(profile.name);
+    const tempPath = `${profilePath}.tmp.${process.pid}`;
+
+    try {
+      // Write to temp file first
+      await fs.promises.writeFile(tempPath, JSON.stringify(profile, null, 2), {
+        encoding: 'utf-8',
+        mode: FILE_MODE,
+      });
+
+      // Atomic rename
+      await fs.promises.rename(tempPath, profilePath);
+    } catch (error) {
+      // Clean up temp file on failure
+      try {
+        await fs.promises.unlink(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a profile by name
+   */
+  async delete(name: string): Promise<void> {
+    if (!isValidProfileName(name)) {
+      throw new Error(`Invalid profile name: ${name}`);
+    }
+
+    const profilePath = getProfilePath(name);
+
+    if (fs.existsSync(profilePath)) {
+      await fs.promises.unlink(profilePath);
+    }
+
+    // Clear active profile if this was the active one
+    const active = await this.getActive();
+    if (active === name) {
+      await this.clearActive();
+    }
+  }
+
+  /**
+   * Check if a profile exists
+   */
+  async exists(name: string): Promise<boolean> {
+    if (!isValidProfileName(name)) {
+      return false;
+    }
+
+    const profilePath = getProfilePath(name);
+    try {
+      await fs.promises.access(profilePath, fs.constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get the active profile name
+   */
+  async getActive(): Promise<string | null> {
+    const activePath = getActiveProfilePath();
+
+    if (!fs.existsSync(activePath)) {
+      return null;
+    }
+
+    try {
+      const content = await fs.promises.readFile(activePath, 'utf-8');
+      const name = content.trim();
+
+      if (!name || !isValidProfileName(name)) {
+        return null;
+      }
+
+      // Verify the profile actually exists
+      if (!(await this.exists(name))) {
+        return null;
+      }
+
+      return name;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Set the active profile
+   */
+  async setActive(name: string): Promise<void> {
+    if (!isValidProfileName(name)) {
+      throw new Error(`Invalid profile name: ${name}`);
+    }
+
+    // Verify profile exists
+    if (!(await this.exists(name))) {
+      throw new Error(`Profile not found: ${name}`);
+    }
+
+    await this.ensureDirectories();
+
+    const activePath = getActiveProfilePath();
+    const tempPath = `${activePath}.tmp.${process.pid}`;
+
+    try {
+      await fs.promises.writeFile(tempPath, name, {
+        encoding: 'utf-8',
+        mode: FILE_MODE,
+      });
+      await fs.promises.rename(tempPath, activePath);
+    } catch (error) {
+      try {
+        await fs.promises.unlink(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Clear the active profile
+   */
+  async clearActive(): Promise<void> {
+    const activePath = getActiveProfilePath();
+
+    if (fs.existsSync(activePath)) {
+      await fs.promises.unlink(activePath);
+    }
+  }
+
+  /**
+   * Get the active profile (full profile object)
+   */
+  async getActiveProfile(): Promise<Profile | null> {
+    const name = await this.getActive();
+
+    if (!name) {
+      return null;
+    }
+
+    return this.get(name);
+  }
+
+  /**
+   * Get profile with environment variable overrides applied
+   * Environment variables take precedence over profile settings
+   */
+  async getActiveProfileWithEnvOverrides(): Promise<Profile | null> {
+    const profile = await this.getActiveProfile();
+
+    if (!profile) {
+      // Check if we can construct a profile purely from env vars
+      const envApiUrl = process.env.F5XC_API_URL;
+      const envApiToken = process.env.F5XC_API_TOKEN;
+
+      if (envApiUrl && envApiToken) {
+        return {
+          name: 'env',
+          apiUrl: envApiUrl,
+          apiToken: envApiToken,
+          defaultNamespace: process.env.F5XC_NAMESPACE,
+        };
+      }
+
+      return null;
+    }
+
+    // Apply environment variable overrides
+    return {
+      ...profile,
+      apiUrl: process.env.F5XC_API_URL || profile.apiUrl,
+      apiToken: process.env.F5XC_API_TOKEN || profile.apiToken,
+      p12Bundle: process.env.F5XC_P12_BUNDLE || profile.p12Bundle,
+      cert: process.env.F5XC_CERT || profile.cert,
+      key: process.env.F5XC_KEY || profile.key,
+      defaultNamespace: process.env.F5XC_NAMESPACE || profile.defaultNamespace,
+    };
+  }
+}
+
+// Singleton instance for convenience
+export const xdgProfileManager = new XDGProfileManager();

--- a/src/providers/cloudStatusDashboardProvider.ts
+++ b/src/providers/cloudStatusDashboardProvider.ts
@@ -1733,7 +1733,7 @@ export class CloudStatusDashboardProvider {
     // Try to fetch Regional Edge data from XC API if authenticated
     // Note: F5-managed Regional Edge sites are visible in LIST but coordinates are not accessible
     let xcSite: Site | null = null;
-    const activeProfile = this.profileManager.getActiveProfile();
+    const activeProfile = await this.profileManager.getActiveProfile();
 
     if (activeProfile && siteCode) {
       try {

--- a/src/test/unit/auth.test.ts
+++ b/src/test/unit/auth.test.ts
@@ -29,7 +29,7 @@ interface MockRequest {
 describe('TokenAuthProvider', () => {
   const mockConfig = {
     apiUrl: 'https://tenant.console.ves.volterra.io',
-    token: 'test-api-token-12345',
+    apiToken: 'test-api-token-12345',
   };
 
   let provider: TokenAuthProvider;
@@ -249,7 +249,7 @@ describe('TokenAuthProvider with different configurations', () => {
   it('should handle URL with trailing slash', () => {
     const provider = new TokenAuthProvider({
       apiUrl: 'https://tenant.console.ves.volterra.io/',
-      token: 'test-token',
+      apiToken: 'test-token',
     });
 
     const headers = provider.getHeaders();
@@ -261,7 +261,7 @@ describe('TokenAuthProvider with different configurations', () => {
   it('should handle URL without protocol prefix in token', () => {
     const provider = new TokenAuthProvider({
       apiUrl: 'https://tenant.console.ves.volterra.io',
-      token: 'simple-token',
+      apiToken: 'simple-token',
     });
 
     const headers = provider.getHeaders();
@@ -274,7 +274,7 @@ describe('TokenAuthProvider with different configurations', () => {
     const specialToken = 'token-with-special-chars!@#$%';
     const provider = new TokenAuthProvider({
       apiUrl: 'https://test.example.com',
-      token: specialToken,
+      apiToken: specialToken,
     });
 
     const headers = provider.getHeaders();
@@ -286,7 +286,7 @@ describe('TokenAuthProvider with different configurations', () => {
   it('should handle empty token', () => {
     const provider = new TokenAuthProvider({
       apiUrl: 'https://test.example.com',
-      token: '',
+      apiToken: '',
     });
 
     const headers = provider.getHeaders();
@@ -330,7 +330,7 @@ describe('TokenAuthProvider validation URL construction', () => {
 
     const provider = new TokenAuthProvider({
       apiUrl: 'https://mytenant.console.ves.volterra.io',
-      token: 'test-token',
+      apiToken: 'test-token',
     });
 
     await provider.validate();

--- a/src/tree/f5xcExplorer.ts
+++ b/src/tree/f5xcExplorer.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ProfileManager, F5XCProfile } from '../config/profiles';
+import { ProfileManager, Profile } from '../config/profiles';
 import { F5XCClient } from '../api/client';
 import {
   RESOURCE_TYPES,
@@ -32,12 +32,12 @@ export class F5XCExplorerProvider implements vscode.TreeDataProvider<F5XCTreeIte
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
   private readonly profileManager: ProfileManager;
-  private readonly clientFactory: (profile: F5XCProfile) => Promise<F5XCClient>;
+  private readonly clientFactory: (profile: Profile) => Promise<F5XCClient>;
   private readonly logger = getLogger();
 
   constructor(
     profileManager: ProfileManager,
-    clientFactory: (profile: F5XCProfile) => Promise<F5XCClient>,
+    clientFactory: (profile: Profile) => Promise<F5XCClient>,
   ) {
     this.profileManager = profileManager;
     this.clientFactory = clientFactory;
@@ -59,7 +59,7 @@ export class F5XCExplorerProvider implements vscode.TreeDataProvider<F5XCTreeIte
   }
 
   private async getRootItems(): Promise<F5XCTreeItem[]> {
-    const activeProfile = this.profileManager.getActiveProfile();
+    const activeProfile = await this.profileManager.getActiveProfile();
 
     if (!activeProfile) {
       return [];
@@ -128,7 +128,7 @@ class NamespaceGroupNode implements F5XCTreeItem {
     private readonly groupName: string,
     private readonly namespaceNames: string[],
     private readonly profileName: string,
-    private readonly clientFactory: (profile: F5XCProfile) => Promise<F5XCClient>,
+    private readonly clientFactory: (profile: Profile) => Promise<F5XCClient>,
     private readonly profileManager: ProfileManager,
     private readonly icon: string,
     private readonly isBuiltIn: boolean,
@@ -162,7 +162,7 @@ class NamespaceGroupNode implements F5XCTreeItem {
 export class NamespaceNode implements F5XCTreeItem {
   constructor(
     private readonly data: NamespaceNodeData,
-    private readonly clientFactory: (profile: F5XCProfile) => Promise<F5XCClient>,
+    private readonly clientFactory: (profile: Profile) => Promise<F5XCClient>,
     private readonly profileManager: ProfileManager,
   ) {}
 
@@ -213,7 +213,7 @@ export class NamespaceNode implements F5XCTreeItem {
 class CategoryNode implements F5XCTreeItem {
   constructor(
     private readonly data: CategoryNodeData,
-    private readonly clientFactory: (profile: F5XCProfile) => Promise<F5XCClient>,
+    private readonly clientFactory: (profile: Profile) => Promise<F5XCClient>,
     private readonly profileManager: ProfileManager,
   ) {}
 
@@ -259,7 +259,7 @@ class ResourceTypeNode implements F5XCTreeItem {
 
   constructor(
     private readonly data: ResourceTypeNodeData,
-    private readonly clientFactory: (profile: F5XCProfile) => Promise<F5XCClient>,
+    private readonly clientFactory: (profile: Profile) => Promise<F5XCClient>,
     private readonly profileManager: ProfileManager,
   ) {}
 
@@ -319,7 +319,7 @@ class ResourceTypeNode implements F5XCTreeItem {
 
   async getChildren(): Promise<F5XCTreeItem[]> {
     try {
-      const profile = this.profileManager.getProfile(this.data.profileName);
+      const profile = await this.profileManager.getProfile(this.data.profileName);
       if (!profile) {
         return [];
       }

--- a/src/tree/subscriptionProvider.ts
+++ b/src/tree/subscriptionProvider.ts
@@ -28,7 +28,7 @@ export class SubscriptionProvider implements vscode.TreeDataProvider<F5XCTreeIte
     }
 
     // Root level - return Plan and Quotas nodes if there's an active profile
-    const activeProfile = this.profileManager.getActiveProfile();
+    const activeProfile = await this.profileManager.getActiveProfile();
     if (!activeProfile) {
       return [];
     }


### PR DESCRIPTION
## Summary

- Implement XDG-compliant file-based profile storage for cross-tool compatibility
- Replace VSCode SecretStorage with `~/.config/xcsh/profiles/{name}.json`
- Unify P12 and cert+key authentication into single CertAuthProvider
- Add environment variable override support

## Changes

### New Files
- `src/config/paths.ts` - XDG path utilities (cross-platform)
- `src/config/xdgProfiles.ts` - XDG ProfileManager with atomic writes
- `src/api/auth/certAuth.ts` - Unified P12/cert+key authentication

### Modified
- `src/config/profiles.ts` - Rewrote to use XDG file storage
- `src/commands/profile.ts` - Updated prompts for new field names
- Tree providers - Updated for async profile operations
- Tests - Rewrote with XDG mocks

### Deleted
- `src/api/auth/p12Auth.ts` - Replaced by certAuth.ts

## Compatibility

Profiles are now shared with:
- `f5xc-xcsh` CLI tool
- `f5xc-api-mcp` MCP server

## Auth Methods

| Method | Field | Description |
|--------|-------|-------------|
| Token | `apiToken` | Authorization: APIToken {token} |
| P12 | `p12Bundle` | mTLS via node-forge (password from F5XC_P12_PASSWORD) |
| Cert+Key | `cert`, `key` | Direct PEM file loading |

## Test plan

- [x] All 349 unit tests pass
- [x] TypeScript compilation succeeds
- [x] ESLint passes (0 errors)
- [ ] CI pipeline passes
- [ ] Extension loads without errors
- [ ] Profile CRUD operations work
- [ ] Cross-tool sync with f5xc-xcsh

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)