### PR TITLE
refactor: change profile config directory from xcsh to f5xc

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,8 +1,8 @@
 /**
- * XDG Base Directory paths for cross-tool compatibility with f5xc-xcsh and f5xc-api-mcp
+ * XDG Base Directory paths for cross-tool compatibility with F5 XC tools
  *
  * Structure:
- *   ~/.config/xcsh/
+ *   ~/.config/f5xc/
  *   ├── active_profile     # Plain text: active profile name
  *   └── profiles/          # Profile JSON files
  *       ├── profile-1.json
@@ -12,8 +12,8 @@
 import * as path from 'path';
 import * as os from 'os';
 
-/** Application name for XDG directories - matches f5xc-xcsh */
-const APP_NAME = 'xcsh';
+/** Application name for XDG directories - shared across F5 XC tools */
+const APP_NAME = 'f5xc';
 
 /** File permissions: owner read/write only */
 export const FILE_MODE = 0o600;
@@ -22,9 +22,9 @@ export const FILE_MODE = 0o600;
 export const DIR_MODE = 0o700;
 
 /**
- * Get the XDG config directory for xcsh
- * - Windows: %APPDATA%\xcsh
- * - Unix: $XDG_CONFIG_HOME/xcsh or ~/.config/xcsh
+ * Get the XDG config directory for F5 XC tools
+ * - Windows: %APPDATA%\f5xc
+ * - Unix: $XDG_CONFIG_HOME/f5xc or ~/.config/f5xc
  */
 export function getConfigDir(): string {
   if (process.platform === 'win32') {
@@ -65,7 +65,7 @@ export function getProfilePath(name: string): string {
 
 /**
  * Validate profile name - must be alphanumeric, dash, underscore only
- * Max 64 characters (matches f5xc-xcsh)
+ * Max 64 characters
  */
 export function isValidProfileName(name: string): boolean {
   if (!name || name.length > 64) {

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -1,6 +1,6 @@
 /**
  * ProfileManager - XDG-compliant profile management
- * Compatible with f5xc-xcsh and f5xc-api-mcp
+ * Shared across F5 XC tools
  */
 
 import * as vscode from 'vscode';
@@ -22,7 +22,7 @@ export type { Profile } from './xdgProfiles';
 
 /**
  * Manages F5 XC connection profiles with XDG-compliant file storage
- * Compatible with f5xc-xcsh CLI and f5xc-api-mcp
+ * Shared across F5 XC tools (VS Code extension, CLI, MCP servers)
  */
 export class ProfileManager {
   private readonly xdg: XDGProfileManager;
@@ -41,7 +41,7 @@ export class ProfileManager {
 
   /**
    * Initialize file watcher for cross-tool sync
-   * Detects changes made by f5xc-xcsh CLI or other tools
+   * Detects changes made by other F5 XC tools
    */
   private initFileWatcher(): void {
     const profilesDir = getProfilesDir();

--- a/src/config/xdgProfiles.ts
+++ b/src/config/xdgProfiles.ts
@@ -1,9 +1,9 @@
 /**
  * XDG-compliant ProfileManager for cross-tool compatibility
- * Compatible with f5xc-xcsh and f5xc-api-mcp
+ * Shared across F5 XC tools (VS Code extension, CLI, MCP servers)
  *
- * Profiles stored at: ~/.config/xcsh/profiles/{name}.json
- * Active profile at: ~/.config/xcsh/active_profile
+ * Profiles stored at: ~/.config/f5xc/profiles/{name}.json
+ * Active profile at: ~/.config/f5xc/active_profile
  */
 
 import * as fs from 'fs';
@@ -19,7 +19,7 @@ import {
 } from './paths';
 
 /**
- * Profile interface - must match f5xc-xcsh exactly
+ * Profile interface for F5 XC authentication
  */
 export interface Profile {
   name: string;

--- a/src/test/unit/profiles.test.ts
+++ b/src/test/unit/profiles.test.ts
@@ -105,9 +105,9 @@ jest.mock('../../api/auth', () => ({
 
 // Mock paths module
 jest.mock('../../config/paths', () => ({
-  getProfilesDir: jest.fn(() => '/mock/config/xcsh/profiles'),
-  getActiveProfilePath: jest.fn(() => '/mock/config/xcsh/active_profile'),
-  getConfigDir: jest.fn(() => '/mock/config/xcsh'),
+  getProfilesDir: jest.fn(() => '/mock/config/f5xc/profiles'),
+  getActiveProfilePath: jest.fn(() => '/mock/config/f5xc/active_profile'),
+  getConfigDir: jest.fn(() => '/mock/config/f5xc'),
 }));
 
 describe('ProfileManager', () => {


### PR DESCRIPTION
## Summary

Refactor the authentication system to use `~/.config/f5xc/` instead of `~/.config/xcsh/` for storing profiles.

## Rationale

The profile/authentication system is shared across multiple F5 XC tools (VS Code extension, CLI, MCP servers), not just xcsh. Using a more general naming convention (`f5xc`) better reflects this cross-tool architecture.

## Changes

- **src/config/paths.ts**: Change `APP_NAME` from `'xcsh'` to `'f5xc'`
- **src/config/xdgProfiles.ts**: Update documentation and comments
- **src/config/profiles.ts**: Update documentation and comments
- **src/test/unit/profiles.test.ts**: Update mock paths

## New Path Structure

```
~/.config/f5xc/
├── active_profile
└── profiles/
    ├── profile-1.json
    └── profile-2.json
```

## Breaking Change

This is a clean break with no backwards compatibility. Existing profiles in `~/.config/xcsh/` will need to be migrated manually. This is acceptable as this is a pre-release version.

Closes #79