### PR TITLE
chore: update to MIT license with 2026 copyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - "CHANGELOG.md"
+      - CHANGELOG.md
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: "npm"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -81,7 +81,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -143,7 +143,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: "npm"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -187,7 +187,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: "npm"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -216,7 +216,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: "npm"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   push:
     tags:
       # Match new version format: v1.0.77-YYMMDDHHMM or v1.0.77-YYMMDDHHMM-BETA
-      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+-BETA"
+      - v[0-9]+.[0-9]+.[0-9]+-[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-[0-9]+-BETA
   workflow_dispatch:
 
 permissions:
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: "npm"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -70,7 +70,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: "npm"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,6 +101,10 @@ repos:
           - typescript@5.3.3
           - "@typescript-eslint/eslint-plugin@6.15.0"
           - "@typescript-eslint/parser@6.15.0"
+          - "@eslint/js@8.56.0"
+          - typescript-eslint@7.0.0
+          - eslint-config-prettier@9.1.0
+          - globals@13.24.0
 
   # =============================================================================
   # Prettier Code Formatting

--- a/LICENSE
+++ b/LICENSE
@@ -1,190 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Robin Mordasiewicz
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2024 F5 Networks, Inc.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 // Commitlint configuration
 // See https://commitlint.js.org/reference/configuration.html
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /** @type {import('jest').Config} */
 module.exports = {
   preset: 'ts-jest',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-f5xc-tools",
-  "version": "1.0.2512312039",
+  "version": "2.2601.50722",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-f5xc-tools",
-      "version": "1.0.2512312039",
+      "version": "2.2601.50722",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/scripts/check-specs.ts
+++ b/scripts/check-specs.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * API Spec Freshness Check Script
  *

--- a/scripts/generate-doc-urls.ts
+++ b/scripts/generate-doc-urls.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Build-time script to generate documentation URLs from OpenAPI spec files.
  *

--- a/scripts/generators/constants-generator.ts
+++ b/scripts/generators/constants-generator.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Constants generator for F5 XC extension.
  *

--- a/scripts/generators/description-normalizer.ts
+++ b/scripts/generators/description-normalizer.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Description normalizer for F5 XC resource types.
  *

--- a/scripts/generators/domain-category-generator.ts
+++ b/scripts/generators/domain-category-generator.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Domain Category Generator
  *

--- a/scripts/generators/index.ts
+++ b/scripts/generators/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Generator module exports.
  *

--- a/scripts/generators/menu-schema-generator.ts
+++ b/scripts/generators/menu-schema-generator.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Menu Schema Generator
  *

--- a/scripts/generators/resource-type-generator.ts
+++ b/scripts/generators/resource-type-generator.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Resource type generator for F5 XC extension.
  *

--- a/scripts/generators/spec-parser.ts
+++ b/scripts/generators/spec-parser.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * OpenAPI specification parsing utilities for F5 XC resource type generation.
  *

--- a/scripts/sync-specs.ts
+++ b/scripts/sync-specs.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * API Spec Sync Script
  *

--- a/scripts/validate-generation.ts
+++ b/scripts/validate-generation.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Validation script for generated files.
  *

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Version generation script for F5 XC Tools
  *

--- a/src/api/auth/certAuth.ts
+++ b/src/api/auth/certAuth.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Certificate-based authentication provider for F5 XC
  * Supports two methods:

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as https from 'https';
 
 /**

--- a/src/api/auth/tokenAuth.ts
+++ b/src/api/auth/tokenAuth.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as https from 'https';
 import { AuthProvider, TokenAuthConfig } from './index';
 import { getLogger } from '../../utils/logger';

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as https from 'https';
 import { AuthProvider } from './auth';
 import { F5XCApiError } from '../utils/errors';

--- a/src/api/cloudStatus.ts
+++ b/src/api/cloudStatus.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * F5 Cloud Status API Client
  * Fetches status information from https://www.f5cloudstatus.com (Statuspage.io API)

--- a/src/api/geocoder.ts
+++ b/src/api/geocoder.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Geocoder Module
  * Nominatim (OpenStreetMap) geocoding wrapper for location lookup

--- a/src/api/popCoordinates.ts
+++ b/src/api/popCoordinates.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * PoP Coordinates Module
  * Static mapping of known F5 Regional Edge PoP coordinates with geocoding fallback support

--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Subscription and quota API types and methods
  *

--- a/src/commands/cloudStatus.ts
+++ b/src/commands/cloudStatus.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Cloud Status Command Handlers
  * Commands for interacting with the Cloud Status feature

--- a/src/commands/crud.ts
+++ b/src/commands/crud.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { F5XCExplorerProvider, ResourceNode, NamespaceNode } from '../tree/f5xcExplorer';
 import { ProfileManager } from '../config/profiles';

--- a/src/commands/diagram.ts
+++ b/src/commands/diagram.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ResourceNode } from '../tree/f5xcExplorer';
 import { ProfileManager } from '../config/profiles';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,2 +1,4 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 export { registerCrudCommands } from './crud';
 export { registerProfileCommands } from './profile';

--- a/src/commands/observability.ts
+++ b/src/commands/observability.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ResourceNode } from '../tree/f5xcExplorer';
 import { ProfileManager } from '../config/profiles';

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ProfileManager, Profile } from '../config/profiles';
 import { ProfilesProvider, ProfileTreeItem } from '../tree/profilesProvider';

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * XDG Base Directory paths for cross-tool compatibility with F5 XC tools
  *

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * ProfileManager - XDG-compliant profile management
  * Shared across F5 XC tools

--- a/src/config/xdgProfiles.ts
+++ b/src/config/xdgProfiles.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * XDG-compliant ProfileManager for cross-tool compatibility
  * Shared across F5 XC tools (VS Code extension, CLI, MCP servers)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ProfileManager } from './config/profiles';
 import { F5XCExplorerProvider } from './tree/f5xcExplorer';

--- a/src/providers/cloudStatusDashboardProvider.ts
+++ b/src/providers/cloudStatusDashboardProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Cloud Status Dashboard WebView Provider
  * Displays detailed F5 Cloud Status information in a WebView panel

--- a/src/providers/f5xcDescribeProvider.ts
+++ b/src/providers/f5xcDescribeProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ProfileManager } from '../config/profiles';
 import { RESOURCE_TYPES, ResourceTypeInfo } from '../api/resourceTypes';

--- a/src/providers/f5xcDiagramProvider.ts
+++ b/src/providers/f5xcDiagramProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ProfileManager } from '../config/profiles';
 import { getLogger } from '../utils/logger';

--- a/src/providers/f5xcFileSystemProvider.ts
+++ b/src/providers/f5xcFileSystemProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ProfileManager } from '../config/profiles';
 import { RESOURCE_TYPES } from '../api/resourceTypes';

--- a/src/providers/f5xcViewProvider.ts
+++ b/src/providers/f5xcViewProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ProfileManager } from '../config/profiles';
 import { RESOURCE_TYPES, ResourceTypeInfo } from '../api/resourceTypes';

--- a/src/providers/subscriptionDashboardProvider.ts
+++ b/src/providers/subscriptionDashboardProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * WebView provider for subscription plan and quota dashboards
  */

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * VSCode API mock for Jest unit tests
  * This mock provides basic implementations of VSCode APIs used by the extension

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * VSCode Extension Integration Tests
  * These tests run inside the VSCode Extension Development Host

--- a/src/test/integration/index.ts
+++ b/src/test/integration/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * VSCode Integration Test Runner
  * This file is the entry point for running VSCode extension integration tests

--- a/src/test/unit/auth.test.ts
+++ b/src/test/unit/auth.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit tests for Authentication Providers
  */

--- a/src/test/unit/client.test.ts
+++ b/src/test/unit/client.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import { F5XCClient, ListOptions } from '../../api/client';
 import { ResourceTypeInfo, ResourceCategory } from '../../api/resourceTypes';
 

--- a/src/test/unit/cloudStatus.test.ts
+++ b/src/test/unit/cloudStatus.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import {
   CloudStatusClient,
   getStatusDisplayText,

--- a/src/test/unit/cloudStatusTypes.test.ts
+++ b/src/test/unit/cloudStatusTypes.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import { CloudStatusContext } from '../../tree/cloudStatusTypes';
 
 describe('CloudStatusContext', () => {

--- a/src/test/unit/errors.test.ts
+++ b/src/test/unit/errors.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import {
   F5XCApiError,
   ConfigurationError,

--- a/src/test/unit/generators.test.ts
+++ b/src/test/unit/generators.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit tests for the generator functions.
  *

--- a/src/test/unit/geocoder.test.ts
+++ b/src/test/unit/geocoder.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import { geocodeLocation } from '../../api/geocoder';
 
 // Mock the logger module

--- a/src/test/unit/logger.test.ts
+++ b/src/test/unit/logger.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import { Logger, getLogger } from '../../utils/logger';
 import * as vscode from 'vscode';
 

--- a/src/test/unit/popCoordinates.test.ts
+++ b/src/test/unit/popCoordinates.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import {
   Coordinates,
   POP_COORDINATES,

--- a/src/test/unit/profiles.test.ts
+++ b/src/test/unit/profiles.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit tests for the ProfileManager with XDG-compliant storage
  */

--- a/src/test/unit/resourceFilter.test.ts
+++ b/src/test/unit/resourceFilter.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import {
   filterResource,
   getFilterOptionsForViewMode,

--- a/src/test/unit/resourceTypes.test.ts
+++ b/src/test/unit/resourceTypes.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit tests for the Resource Types registry
  */

--- a/src/test/unit/treeTypes.test.ts
+++ b/src/test/unit/treeTypes.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import { TreeItemContext } from '../../tree/treeTypes';
 
 describe('TreeItemContext', () => {

--- a/src/test/unit/validation.test.ts
+++ b/src/test/unit/validation.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit tests for the validation utilities
  */

--- a/src/tree/cloudStatusProvider.ts
+++ b/src/tree/cloudStatusProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Cloud Status Tree Provider
  * TreeDataProvider for F5 Cloud Status information

--- a/src/tree/cloudStatusTypes.ts
+++ b/src/tree/cloudStatusTypes.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Cloud Status Tree Types
  * Types and interfaces for the Cloud Status tree view

--- a/src/tree/f5xcExplorer.ts
+++ b/src/tree/f5xcExplorer.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ProfileManager, Profile } from '../config/profiles';
 import { F5XCClient } from '../api/client';

--- a/src/tree/profilesProvider.ts
+++ b/src/tree/profilesProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ProfileManager, Profile } from '../config/profiles';
 import { F5XCTreeItem } from './treeTypes';

--- a/src/tree/subscriptionNodes.ts
+++ b/src/tree/subscriptionNodes.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Subscription tree nodes for Plan and Quota sections
  */

--- a/src/tree/subscriptionProvider.ts
+++ b/src/tree/subscriptionProvider.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Subscription tree data provider
  * Provides a separate top-level view for Plan and Quotas

--- a/src/tree/treeTypes.ts
+++ b/src/tree/treeTypes.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { ResourceCategory, ResourceTypeInfo } from '../api/resourceTypes';
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 import { getLogger } from './logger';
 import { getSmartErrorMessage } from '../api/resourceTypes';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import * as vscode from 'vscode';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';

--- a/src/utils/resourceFilter.ts
+++ b/src/utils/resourceFilter.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Resource filtering utilities to match F5 Console display format
  *

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Validation utilities for F5 XC resource operations.
  *

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 //@ts-check
 'use strict';
 


### PR DESCRIPTION
## Summary
Updates license from Apache 2.0 to MIT and bumps copyright year to 2026 across all source files, configuration files, and workflow definitions. Also improves pre-commit hook configuration for better ESLint compatibility with flat config format.

## Changes
- Update LICENSE file from Apache 2.0 to MIT
- Bump copyright year to 2026 in all source files
- Fix redundant YAML quotes in workflow definitions
- Improve pre-commit hook dependencies for ESLint flat config support

## Testing
- ESLint validation passed on all TypeScript files
- TypeScript type checking passed
- npm security audit passed
- All pre-commit hooks passed (except known Python 3.14 compatibility issue with semgrep)

## Issue
Closes #82

Generated with Claude Code