### PR TITLE
feat: add field metadata generation and validation

### DIFF
--- a/.github/workflows/spec-update-check.yml
+++ b/.github/workflows/spec-update-check.yml
@@ -3,7 +3,7 @@ name: API Spec Update Check
 on:
   schedule:
     # Run daily at 2 AM UTC (adjust as needed)
-    - cron: "0 2 * * *"
+    - cron: 0 2 * * *
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/src/test/unit/generators.test.ts
+++ b/src/test/unit/generators.test.ts
@@ -270,4 +270,50 @@ describe('Generated Files Contract', () => {
       expect(validScopes).toContain(resource.namespaceScope);
     }
   });
+
+  it('should have valid fieldMetadata structure when present', () => {
+    const generated = require('../../generated/resourceTypesBase');
+
+    for (const key of Object.keys(generated.GENERATED_RESOURCE_TYPES)) {
+      const resource = generated.GENERATED_RESOURCE_TYPES[key];
+
+      // fieldMetadata is optional - only validate if present
+      if (resource.fieldMetadata) {
+        expect(resource.fieldMetadata).toHaveProperty('fields');
+        expect(typeof resource.fieldMetadata.fields).toBe('object');
+
+        // serverDefaultFields should be array if present
+        if (resource.fieldMetadata.serverDefaultFields) {
+          expect(Array.isArray(resource.fieldMetadata.serverDefaultFields)).toBe(true);
+        }
+
+        // userRequiredFields should be array if present
+        if (resource.fieldMetadata.userRequiredFields) {
+          expect(Array.isArray(resource.fieldMetadata.userRequiredFields)).toBe(true);
+        }
+
+        // Each field entry should have valid structure
+        for (const fieldPath of Object.keys(resource.fieldMetadata.fields)) {
+          const field = resource.fieldMetadata.fields[fieldPath];
+          expect(typeof field).toBe('object');
+
+          // If serverDefault is present, should be boolean
+          if (field.serverDefault !== undefined) {
+            expect(typeof field.serverDefault).toBe('boolean');
+          }
+
+          // If requiredFor is present, should have valid structure
+          if (field.requiredFor) {
+            expect(typeof field.requiredFor).toBe('object');
+            if (field.requiredFor.create !== undefined) {
+              expect(typeof field.requiredFor.create).toBe('boolean');
+            }
+            if (field.requiredFor.update !== undefined) {
+              expect(typeof field.requiredFor.update).toBe('boolean');
+            }
+          }
+        }
+      }
+    }
+  });
 });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -5,9 +5,15 @@
  *
  * Provides pre-validation of resource payloads before API calls,
  * checking required fields and providing user-friendly warnings.
+ * Server-defaulted fields are handled gracefully with hints.
  */
 
-import { getRequiredFields } from '../api/resourceTypes';
+import {
+  getRequiredFields,
+  isFieldServerDefaulted,
+  getUserRequiredFields,
+  getServerDefaultFields,
+} from '../api/resourceTypes';
 
 /**
  * Result of validating a resource payload
@@ -15,10 +21,14 @@ import { getRequiredFields } from '../api/resourceTypes';
 export interface ValidationResult {
   /** Whether the payload is valid */
   valid: boolean;
-  /** List of missing required fields */
+  /** List of missing required fields that user must provide */
   missingFields: string[];
+  /** List of missing fields that server will provide defaults for */
+  serverDefaultedFields: string[];
   /** Warning messages for the user */
   warnings: string[];
+  /** Informational hints about server defaults */
+  hints: string[];
 }
 
 /**
@@ -92,30 +102,59 @@ function formatFieldName(path: string): string {
 /**
  * Validate a resource payload before create or update operation.
  *
+ * Uses the new field metadata system to distinguish between:
+ * - Fields user must provide (required AND not server-defaulted)
+ * - Fields server will provide defaults for (server-defaulted)
+ *
  * @param resourceKey - The resource type key (e.g., 'http_loadbalancer')
  * @param operation - The operation type ('create' or 'update')
  * @param payload - The resource payload to validate
- * @returns Validation result with missing fields and warnings
+ * @returns Validation result with missing fields, server-defaulted fields, and hints
  */
 export function validateResourcePayload(
   resourceKey: string,
   operation: 'create' | 'update',
   payload: Record<string, unknown>,
 ): ValidationResult {
+  // Get fields user must provide (required AND not server-defaulted)
+  const userRequiredFields = getUserRequiredFields(resourceKey, operation);
+  const payloadUserRequired = filterPayloadFields(userRequiredFields);
+
+  // Get fields that are "required" by spec but have server defaults
   const requiredFields = getRequiredFields(resourceKey, operation);
-  const payloadFields = filterPayloadFields(requiredFields);
+  const payloadRequired = filterPayloadFields(requiredFields);
+
+  // Get all server-defaulted fields for this resource
+  const allServerDefaults = getServerDefaultFields(resourceKey);
 
   const missingFields: string[] = [];
+  const serverDefaultedFields: string[] = [];
   const warnings: string[] = [];
+  const hints: string[] = [];
 
-  for (const field of payloadFields) {
+  // Check user-required fields (truly required, no server defaults)
+  for (const field of payloadUserRequired) {
     const value = getNestedValue(payload, field);
     if (!isValuePresent(value)) {
       missingFields.push(field);
     }
   }
 
-  // Build warnings for missing fields
+  // Check fields that are required but server-defaulted
+  // These won't block validation but we inform the user
+  for (const field of payloadRequired) {
+    // Skip if already in user required (not server-defaulted)
+    if (payloadUserRequired.includes(field)) {
+      continue;
+    }
+
+    const value = getNestedValue(payload, field);
+    if (!isValuePresent(value) && isFieldServerDefaulted(resourceKey, field)) {
+      serverDefaultedFields.push(field);
+    }
+  }
+
+  // Build warnings for truly missing required fields
   if (missingFields.length > 0) {
     const fieldNames = missingFields.map(formatFieldName);
     if (missingFields.length === 1) {
@@ -125,10 +164,30 @@ export function validateResourcePayload(
     }
   }
 
+  // Build hints for server-defaulted fields
+  if (serverDefaultedFields.length > 0) {
+    const fieldNames = serverDefaultedFields.map(formatFieldName);
+    if (serverDefaultedFields.length === 1) {
+      hints.push(`Server will provide default for: ${fieldNames[0]}`);
+    } else {
+      hints.push(`Server will provide defaults for:\n• ${fieldNames.join('\n• ')}`);
+    }
+  }
+
+  // Add hint about available server defaults if there are any
+  if (allServerDefaults.length > 0 && Object.keys(payload.spec || {}).length === 0) {
+    hints.push(
+      `This resource type has ${allServerDefaults.length} field(s) with server defaults. ` +
+        `You can omit these fields and the server will provide values.`,
+    );
+  }
+
   return {
     valid: missingFields.length === 0,
     missingFields,
+    serverDefaultedFields,
     warnings,
+    hints,
   };
 }
 


### PR DESCRIPTION
Closes #91

## Summary
Implement automatic extraction and validation of field metadata from F5 XC API specifications, enabling smarter CRUD operations with awareness of server defaults and field requirements.

## Changes
- New spec-parser module for extracting field metadata from OpenAPI specs
- Enhanced resource-type-generator to include field metadata in generated types
- Added field metadata to 40+ F5 XC resource type definitions
- Implemented field validation utilities for constraints and defaults
- Added 154 new lines of comprehensive unit tests
- Fixed YAML linting in spec-update-check workflow

## Benefits
- Automatic detection of server defaults for fields
- Validation of required fields for create/update operations
- Improved error messages for missing required fields
- Foundation for smarter form generation with field hints