### PR TITLE
fix: move healthcheck to LoadBalancing resource category

### DIFF
--- a/docs/automated-spec-updates.md
+++ b/docs/automated-spec-updates.md
@@ -101,10 +101,12 @@ Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.co
 #### Validation Phase
 
 1. **Sync Specs:** `npm run specs:ensure`
+
    - Downloads latest specs from upstream
    - Extracts to `docs/specifications/api/`
 
 2. **Generate Code:** `npm run generate`
+
    - Parses 38+ domain OpenAPI specs
    - Generates TypeScript resource types
    - Creates domain categories and documentation URLs
@@ -118,6 +120,7 @@ Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.co
 #### Testing Phase
 
 1. **Multi-Platform Tests:**
+
    - Ubuntu, macOS, Windows
    - Lint, type check, unit tests
    - Integration tests with VSCode
@@ -129,6 +132,7 @@ Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.co
 #### Build Phase
 
 1. **Webpack Production Build:**
+
    - Bundles extension code
    - Minifies and tree-shakes
    - Generates source maps
@@ -140,11 +144,13 @@ Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.co
 #### Release Phase (Main branch only)
 
 1. **Version Generation:**
+
    - Format: `2.YYMM.DDHHMMSS`
    - Example: `2.2601.161430` (2026-01-16 14:30)
    - Includes upstream spec version in metadata
 
 2. **GitHub Release:**
+
    - Creates git tag
    - Publishes VSIX to GitHub Releases
    - Includes changelog and upstream version

--- a/src/api/resourceTypes.ts
+++ b/src/api/resourceTypes.ts
@@ -252,8 +252,8 @@ const RESOURCE_TYPE_OVERRIDES: Record<string, ResourceTypeOverride> = {
     icon: 'cloud',
   },
   healthcheck: {
-    // upstream x-f5xc-primary-resources specifies category: "Monitoring", map to Observability
-    category: ResourceCategory.Observability,
+    // Health checks are used with origin pools and load balancers - group with Load Balancing
+    category: ResourceCategory.LoadBalancing,
     supportsCustomOps: false,
     icon: 'heart',
   },


### PR DESCRIPTION
Move healthcheck resource from Observability to LoadBalancing category.

Health checks are functionally part of load balancing infrastructure since they are used with origin pools and load balancers.

Closes #97