### PR TITLE
feat: implement dynamic schema provider for json intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -525,19 +525,35 @@
     "jsonValidation": [
       {
         "fileMatch": "*.f5xc.json",
-        "url": "./schemas/f5xc-resource.schema.json"
+        "url": "f5xc-schema://schemas/generic.json"
       },
       {
         "fileMatch": "*.http_loadbalancer.json",
-        "url": "./schemas/http_loadbalancer.schema.json"
+        "url": "f5xc-schema://schemas/http_loadbalancer.json"
       },
       {
         "fileMatch": "*.origin_pool.json",
-        "url": "./schemas/origin_pool.schema.json"
+        "url": "f5xc-schema://schemas/origin_pool.json"
       },
       {
         "fileMatch": "*.app_firewall.json",
-        "url": "./schemas/app_firewall.schema.json"
+        "url": "f5xc-schema://schemas/app_firewall.json"
+      },
+      {
+        "fileMatch": "*.healthcheck.json",
+        "url": "f5xc-schema://schemas/healthcheck.json"
+      },
+      {
+        "fileMatch": "*.tcp_loadbalancer.json",
+        "url": "f5xc-schema://schemas/tcp_loadbalancer.json"
+      },
+      {
+        "fileMatch": "*.dns_load_balancer.json",
+        "url": "f5xc-schema://schemas/dns_load_balancer.json"
+      },
+      {
+        "fileMatch": "*.virtual_site.json",
+        "url": "f5xc-schema://schemas/virtual_site.json"
       }
     ]
   },

--- a/src/providers/f5xcSchemaProvider.ts
+++ b/src/providers/f5xcSchemaProvider.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Schema Provider for F5 XC resource types.
+ * Provides JSON Schemas via the f5xc-schema:// URI scheme for VSCode's JSON IntelliSense.
+ */
+
+import * as vscode from 'vscode';
+import { getSchemaRegistry } from '../schema/schemaRegistry';
+import { getLogger } from '../utils/logger';
+
+const logger = getLogger();
+
+/**
+ * TextDocumentContentProvider for F5 XC JSON Schemas.
+ * Enables VSCode's JSON language service to fetch schemas for IntelliSense.
+ *
+ * URI format: f5xc-schema://schemas/{resourceType}.json
+ * Examples:
+ *   - f5xc-schema://schemas/http_loadbalancer.json
+ *   - f5xc-schema://schemas/origin_pool.json
+ *   - f5xc-schema://schemas/generic.json
+ */
+export class F5XCSchemaProvider implements vscode.TextDocumentContentProvider {
+  private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+  readonly onDidChange = this._onDidChange.event;
+
+  /**
+   * Provide the content for a schema URI.
+   * VSCode's JSON language service calls this when it needs a schema.
+   */
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    // Parse the URI to extract resource type
+    // URI format: f5xc-schema://schemas/{resourceType}.json
+    const path = uri.path;
+    const match = path.match(/\/schemas\/(.+)\.json$/);
+
+    if (!match) {
+      logger.warn(`Invalid schema URI format: ${uri.toString()}`);
+      return this.getErrorSchema(uri.toString());
+    }
+
+    const resourceType = match[1] as string;
+    logger.debug(`Providing schema for resource type: ${resourceType}`);
+
+    const registry = getSchemaRegistry();
+    return registry.getSchemaContent(resourceType);
+  }
+
+  /**
+   * Generate an error schema when the URI is invalid.
+   */
+  private getErrorSchema(uri: string): string {
+    return JSON.stringify(
+      {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        title: 'Error',
+        description: `Invalid schema URI: ${uri}`,
+        type: 'object',
+      },
+      null,
+      2,
+    );
+  }
+
+  /**
+   * Notify that a schema has changed (e.g., after regeneration).
+   */
+  notifySchemaChanged(resourceType: string): void {
+    const uri = vscode.Uri.parse(`f5xc-schema://schemas/${resourceType}.json`);
+    this._onDidChange.fire(uri);
+    logger.debug(`Schema change notified for: ${resourceType}`);
+  }
+
+  /**
+   * Notify that all schemas have changed.
+   */
+  notifyAllSchemasChanged(): void {
+    const registry = getSchemaRegistry();
+    for (const resourceType of registry.getAvailableResourceTypes()) {
+      this.notifySchemaChanged(resourceType);
+    }
+    this.notifySchemaChanged('generic');
+    logger.debug('All schema changes notified');
+  }
+}
+
+/**
+ * Configure JSON schema associations for the f5xc:// file system.
+ * This function sets up VSCode's JSON language service to use our schemas.
+ */
+export function configureJsonSchemaAssociations(): void {
+  // Get the JSON extension's configuration
+  const jsonConfig = vscode.workspace.getConfiguration('json');
+
+  // Get existing schema associations
+  const existingSchemas = jsonConfig.get<Record<string, string | string[]>>('schemas') || {};
+
+  // Build schema associations for f5xc:// URIs
+  const registry = getSchemaRegistry();
+  const resourceTypes = registry.getAvailableResourceTypes();
+
+  // Create schema associations for each resource type
+  const schemaAssociations: Record<string, string[]> = { ...existingSchemas } as Record<
+    string,
+    string[]
+  >;
+
+  for (const resourceType of resourceTypes) {
+    const schemaUri = `f5xc-schema://schemas/${resourceType}.json`;
+    // Match pattern: f5xc://*/{namespace}/{resourceType}/*.json
+    const fileMatch = `f5xc://*/*/${resourceType}/*.json`;
+
+    if (!schemaAssociations[schemaUri]) {
+      schemaAssociations[schemaUri] = [];
+    }
+    if (!schemaAssociations[schemaUri].includes(fileMatch)) {
+      schemaAssociations[schemaUri].push(fileMatch);
+    }
+  }
+
+  // Add generic schema for unrecognized resource types
+  const genericSchemaUri = 'f5xc-schema://schemas/generic.json';
+  if (!schemaAssociations[genericSchemaUri]) {
+    schemaAssociations[genericSchemaUri] = ['f5xc://**/*.json'];
+  }
+
+  // Note: VSCode's json.schemas setting is workspace-specific and read-only
+  // We use the jsonValidation contribution in package.json instead
+  logger.debug(`Schema associations configured for ${resourceTypes.length} resource types`);
+}
+
+/**
+ * Get the schema URI for a specific f5xc:// document URI.
+ * Extracts the resource type from the document URI and returns the schema URI.
+ *
+ * @param documentUri - The f5xc:// URI of the document
+ * @returns The f5xc-schema:// URI for the schema, or null if not applicable
+ */
+export function getSchemaUriForDocument(documentUri: vscode.Uri): vscode.Uri | null {
+  if (documentUri.scheme !== 'f5xc') {
+    return null;
+  }
+
+  // Parse the URI: f5xc://profile/namespace/resourceType/resourceName.json
+  const parts = documentUri.path.split('/').filter((p) => p.length > 0);
+
+  if (parts.length < 3) {
+    return null;
+  }
+
+  // resourceType is the second-to-last part (before resourceName.json)
+  const resourceType = parts[1];
+
+  if (!resourceType) {
+    return null;
+  }
+
+  const registry = getSchemaRegistry();
+  if (registry.hasSchema(resourceType)) {
+    return vscode.Uri.parse(`f5xc-schema://schemas/${resourceType}.json`);
+  }
+
+  // Fall back to generic schema
+  return vscode.Uri.parse('f5xc-schema://schemas/generic.json');
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Schema module exports for F5 XC JSON IntelliSense.
+ */
+
+export {
+  generateSchemaForResourceType,
+  generateGenericSchema,
+  getSchemaResourceTypes,
+  hasDetailedFieldMetadata,
+} from './schemaGenerator';
+export type { F5XCJsonSchema, SchemaProperty } from './schemaGenerator';
+
+export { SchemaRegistry, getSchemaRegistry, resetSchemaRegistry } from './schemaRegistry';

--- a/src/schema/schemaGenerator.ts
+++ b/src/schema/schemaGenerator.ts
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * JSON Schema generator for F5 XC resource types.
+ * Generates schemas from field metadata to enable VSCode IntelliSense.
+ */
+
+import {
+  GENERATED_RESOURCE_TYPES,
+  GeneratedResourceTypeInfo,
+  GeneratedFieldMetadata,
+} from '../generated/resourceTypesBase';
+
+/**
+ * JSON Schema draft-07 compatible property definition
+ */
+export interface SchemaProperty {
+  type?: string | string[];
+  description?: string;
+  default?: unknown;
+  enum?: string[];
+  properties?: Record<string, SchemaProperty>;
+  items?: SchemaProperty;
+  additionalProperties?: SchemaProperty | boolean;
+  $ref?: string;
+  required?: string[];
+  // F5 XC custom extensions for IntelliSense hints
+  'x-f5xc-required'?: boolean;
+  'x-f5xc-server-default'?: boolean;
+  'x-f5xc-recommended-value'?: unknown;
+}
+
+/**
+ * Complete JSON Schema for an F5 XC resource type
+ */
+export interface F5XCJsonSchema {
+  $schema: string;
+  $id: string;
+  title: string;
+  description?: string;
+  type: 'object';
+  properties: Record<string, SchemaProperty>;
+  required?: string[];
+  definitions?: Record<string, SchemaProperty>;
+}
+
+/**
+ * Parse a dot-notation field path and set a value in a nested object.
+ * Creates intermediate objects as needed.
+ */
+function setNestedProperty(
+  obj: Record<string, SchemaProperty>,
+  path: string,
+  props: Partial<SchemaProperty>,
+): void {
+  const parts = path.split('.');
+  let current = obj;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i] as string;
+    const isLast = i === parts.length - 1;
+
+    if (isLast) {
+      // Set properties on the leaf
+      if (!current[part]) {
+        current[part] = { type: 'string' };
+      }
+      Object.assign(current[part], props);
+    } else {
+      // Create intermediate nested object
+      if (!current[part]) {
+        current[part] = {
+          type: 'object',
+          properties: {},
+        };
+      }
+      if (!current[part].properties) {
+        current[part].properties = {};
+      }
+      current = current[part].properties!;
+    }
+  }
+}
+
+/**
+ * Build metadata schema with standard F5 XC resource metadata fields
+ */
+function buildMetadataSchema(): SchemaProperty {
+  return {
+    type: 'object',
+    description: 'Resource metadata containing identification and organizational information',
+    properties: {
+      name: {
+        type: 'string',
+        description: 'Resource name (required). Must be unique within the namespace.',
+        'x-f5xc-required': true,
+      },
+      namespace: {
+        type: 'string',
+        description: 'Namespace where the resource resides.',
+      },
+      labels: {
+        type: 'object',
+        description: 'Key-value labels for organizing and selecting resources.',
+        additionalProperties: { type: 'string' },
+      },
+      annotations: {
+        type: 'object',
+        description: 'Key-value annotations for storing non-identifying metadata.',
+        additionalProperties: { type: 'string' },
+      },
+      description: {
+        type: 'string',
+        description: 'Human-readable description of the resource.',
+      },
+      disable: {
+        type: 'boolean',
+        description: 'Set to true to disable this resource.',
+        default: false,
+      },
+    },
+    required: ['name'],
+  };
+}
+
+/**
+ * Build spec schema from resource type field metadata
+ */
+function buildSpecSchema(resourceType: GeneratedResourceTypeInfo): SchemaProperty {
+  const specSchema: SchemaProperty = {
+    type: 'object',
+    description: `${resourceType.displayName} specification`,
+    properties: {},
+  };
+
+  const fieldMetadata = resourceType.fieldMetadata;
+
+  if (!fieldMetadata || !fieldMetadata.fields) {
+    // No field metadata available - return basic schema
+    specSchema.additionalProperties = true;
+    return specSchema;
+  }
+
+  // Process each field in the metadata
+  for (const [fieldPath, metadata] of Object.entries(fieldMetadata.fields)) {
+    // Skip non-spec fields
+    if (!fieldPath.startsWith('spec.')) {
+      continue;
+    }
+
+    const specPath = fieldPath.replace('spec.', '');
+    const props = buildFieldProperties(metadata);
+
+    setNestedProperty(specSchema.properties!, specPath, props);
+  }
+
+  // Mark required fields
+  if (fieldMetadata.userRequiredFields && fieldMetadata.userRequiredFields.length > 0) {
+    const requiredTopLevel: string[] = [];
+    for (const field of fieldMetadata.userRequiredFields) {
+      if (field.startsWith('spec.')) {
+        const specPath = field.replace('spec.', '');
+        // Only add top-level fields to required array
+        const topLevelField = specPath.split('.')[0];
+        if (topLevelField && !requiredTopLevel.includes(topLevelField)) {
+          requiredTopLevel.push(topLevelField);
+        }
+      }
+    }
+    if (requiredTopLevel.length > 0) {
+      specSchema.required = requiredTopLevel;
+    }
+  }
+
+  // Allow additional properties for flexibility
+  specSchema.additionalProperties = true;
+
+  return specSchema;
+}
+
+/**
+ * Build property definition from field metadata
+ */
+function buildFieldProperties(metadata: GeneratedFieldMetadata): Partial<SchemaProperty> {
+  const props: Partial<SchemaProperty> = {};
+
+  // Infer type from default value if available
+  if (metadata.default !== undefined) {
+    props.default = metadata.default;
+    props.type = inferJsonType(metadata.default);
+  }
+
+  // Mark server default fields
+  if (metadata.serverDefault) {
+    props['x-f5xc-server-default'] = true;
+    props.description = (props.description || '') + ' (Server provides default value)';
+  }
+
+  // Mark required fields
+  if (metadata.requiredFor?.create) {
+    props['x-f5xc-required'] = true;
+  }
+
+  // Add recommended value
+  if (metadata.recommendedValue !== undefined) {
+    props['x-f5xc-recommended-value'] = metadata.recommendedValue;
+    props.default = props.default ?? metadata.recommendedValue;
+    // Infer type from recommended value if not already set
+    if (!props.type) {
+      props.type = inferJsonType(metadata.recommendedValue);
+    }
+  }
+
+  return props;
+}
+
+/**
+ * Infer JSON Schema type from a value
+ */
+function inferJsonType(value: unknown): string | string[] {
+  if (value === null) {
+    return ['null', 'string'];
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  if (typeof value === 'object') {
+    return 'object';
+  }
+  if (typeof value === 'boolean') {
+    return 'boolean';
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? 'integer' : 'number';
+  }
+  return 'string';
+}
+
+/**
+ * Generate a JSON Schema for a specific resource type
+ *
+ * @param resourceTypeKey - The key of the resource type (e.g., 'http_loadbalancer')
+ * @returns The generated JSON Schema or null if resource type not found
+ */
+export function generateSchemaForResourceType(resourceTypeKey: string): F5XCJsonSchema | null {
+  const resourceType = GENERATED_RESOURCE_TYPES[resourceTypeKey];
+  if (!resourceType) {
+    return null;
+  }
+
+  const schema: F5XCJsonSchema = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: `f5xc-schema://schemas/${resourceTypeKey}.json`,
+    title: `F5 XC ${resourceType.displayName}`,
+    description: resourceType.description,
+    type: 'object',
+    properties: {
+      metadata: buildMetadataSchema(),
+      spec: buildSpecSchema(resourceType),
+    },
+    required: ['metadata', 'spec'],
+  };
+
+  return schema;
+}
+
+/**
+ * Generate a combined schema that can match any F5 XC resource type
+ */
+export function generateGenericSchema(): F5XCJsonSchema {
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: 'f5xc-schema://schemas/generic.json',
+    title: 'F5 XC Resource',
+    description: 'Generic schema for F5 Distributed Cloud resources',
+    type: 'object',
+    properties: {
+      metadata: buildMetadataSchema(),
+      spec: {
+        type: 'object',
+        description: 'Resource specification',
+        additionalProperties: true,
+      },
+    },
+    required: ['metadata', 'spec'],
+  };
+}
+
+/**
+ * Get list of all resource type keys that have schemas
+ */
+export function getSchemaResourceTypes(): string[] {
+  return Object.keys(GENERATED_RESOURCE_TYPES);
+}
+
+/**
+ * Check if a resource type has detailed field metadata
+ */
+export function hasDetailedFieldMetadata(resourceTypeKey: string): boolean {
+  const resourceType = GENERATED_RESOURCE_TYPES[resourceTypeKey];
+  return !!(
+    resourceType?.fieldMetadata?.fields && Object.keys(resourceType.fieldMetadata.fields).length > 0
+  );
+}

--- a/src/schema/schemaRegistry.ts
+++ b/src/schema/schemaRegistry.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Schema Registry for F5 XC resource types.
+ * Caches generated schemas and provides access by resource type.
+ */
+
+import * as vscode from 'vscode';
+import {
+  generateSchemaForResourceType,
+  generateGenericSchema,
+  getSchemaResourceTypes,
+  F5XCJsonSchema,
+} from './schemaGenerator';
+import { getLogger } from '../utils/logger';
+
+const logger = getLogger();
+
+/**
+ * Registry for caching and managing JSON Schemas for F5 XC resource types.
+ * Implements lazy loading - schemas are generated on first access.
+ */
+export class SchemaRegistry {
+  private schemas = new Map<string, F5XCJsonSchema>();
+  private genericSchema: F5XCJsonSchema | null = null;
+
+  /**
+   * Get the schema URI for a resource type.
+   * The URI uses the f5xc-schema:// scheme for VSCode's JSON language service.
+   */
+  getSchemaUri(resourceType: string): vscode.Uri {
+    return vscode.Uri.parse(`f5xc-schema://schemas/${resourceType}.json`);
+  }
+
+  /**
+   * Get the generic schema URI for any F5 XC resource.
+   */
+  getGenericSchemaUri(): vscode.Uri {
+    return vscode.Uri.parse('f5xc-schema://schemas/generic.json');
+  }
+
+  /**
+   * Get or generate a schema for a specific resource type.
+   * Caches the schema for subsequent requests.
+   *
+   * @param resourceType - The resource type key (e.g., 'http_loadbalancer')
+   * @returns The JSON Schema or null if resource type is unknown
+   */
+  getOrGenerateSchema(resourceType: string): F5XCJsonSchema | null {
+    // Check cache first
+    if (this.schemas.has(resourceType)) {
+      return this.schemas.get(resourceType)!;
+    }
+
+    // Generate schema
+    const schema = generateSchemaForResourceType(resourceType);
+    if (schema) {
+      this.schemas.set(resourceType, schema);
+      logger.debug(`Generated schema for resource type: ${resourceType}`);
+    }
+
+    return schema;
+  }
+
+  /**
+   * Get the generic schema for any F5 XC resource.
+   * Useful as a fallback when the specific resource type is unknown.
+   */
+  getGenericSchema(): F5XCJsonSchema {
+    if (!this.genericSchema) {
+      this.genericSchema = generateGenericSchema();
+      logger.debug('Generated generic F5 XC resource schema');
+    }
+    return this.genericSchema;
+  }
+
+  /**
+   * Get schema content as a JSON string for a resource type.
+   * Used by the TextDocumentContentProvider.
+   *
+   * @param resourceType - The resource type key or 'generic'
+   * @returns JSON string of the schema
+   */
+  getSchemaContent(resourceType: string): string {
+    if (resourceType === 'generic') {
+      return JSON.stringify(this.getGenericSchema(), null, 2);
+    }
+
+    const schema = this.getOrGenerateSchema(resourceType);
+    if (schema) {
+      return JSON.stringify(schema, null, 2);
+    }
+
+    // Fallback to generic schema if resource type is unknown
+    logger.warn(`Unknown resource type: ${resourceType}, using generic schema`);
+    return JSON.stringify(this.getGenericSchema(), null, 2);
+  }
+
+  /**
+   * Get all available resource type keys.
+   */
+  getAvailableResourceTypes(): string[] {
+    return getSchemaResourceTypes();
+  }
+
+  /**
+   * Clear the schema cache.
+   * Useful for testing or when resource types are updated.
+   */
+  clearCache(): void {
+    this.schemas.clear();
+    this.genericSchema = null;
+    logger.debug('Schema cache cleared');
+  }
+
+  /**
+   * Pre-warm the cache by generating schemas for commonly used resource types.
+   * This can improve performance for frequently accessed resources.
+   */
+  prewarmCache(resourceTypes?: string[]): void {
+    const typesToWarm = resourceTypes || [
+      'http_loadbalancer',
+      'origin_pool',
+      'healthcheck',
+      'app_firewall',
+    ];
+
+    for (const type of typesToWarm) {
+      this.getOrGenerateSchema(type);
+    }
+    logger.debug(`Pre-warmed schema cache for ${typesToWarm.length} resource types`);
+  }
+
+  /**
+   * Check if a schema exists for a resource type.
+   */
+  hasSchema(resourceType: string): boolean {
+    if (this.schemas.has(resourceType)) {
+      return true;
+    }
+    // Check if resource type exists (will be generated on access)
+    return getSchemaResourceTypes().includes(resourceType);
+  }
+
+  /**
+   * Get cache statistics for debugging.
+   */
+  getCacheStats(): { cachedCount: number; availableCount: number } {
+    return {
+      cachedCount: this.schemas.size,
+      availableCount: getSchemaResourceTypes().length,
+    };
+  }
+}
+
+/**
+ * Singleton instance of the schema registry.
+ * Use this for accessing schemas throughout the extension.
+ */
+let registryInstance: SchemaRegistry | null = null;
+
+/**
+ * Get the singleton schema registry instance.
+ */
+export function getSchemaRegistry(): SchemaRegistry {
+  if (!registryInstance) {
+    registryInstance = new SchemaRegistry();
+  }
+  return registryInstance;
+}
+
+/**
+ * Reset the schema registry (for testing purposes).
+ */
+export function resetSchemaRegistry(): void {
+  if (registryInstance) {
+    registryInstance.clearCache();
+  }
+  registryInstance = null;
+}

--- a/src/test/unit/schemaGenerator.test.ts
+++ b/src/test/unit/schemaGenerator.test.ts
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Unit tests for the JSON Schema generator
+ */
+
+import {
+  generateSchemaForResourceType,
+  generateGenericSchema,
+  getSchemaResourceTypes,
+  hasDetailedFieldMetadata,
+} from '../../schema/schemaGenerator';
+
+describe('Schema Generator', () => {
+  describe('generateSchemaForResourceType', () => {
+    it('should generate a valid JSON Schema for http_loadbalancer', () => {
+      const schema = generateSchemaForResourceType('http_loadbalancer');
+
+      expect(schema).not.toBeNull();
+      expect(schema!.$schema).toBe('http://json-schema.org/draft-07/schema#');
+      expect(schema!.$id).toBe('f5xc-schema://schemas/http_loadbalancer.json');
+      expect(schema!.title).toContain('F5 XC');
+      expect(schema!.type).toBe('object');
+    });
+
+    it('should include metadata and spec properties', () => {
+      const schema = generateSchemaForResourceType('http_loadbalancer');
+
+      expect(schema).not.toBeNull();
+      expect(schema!.properties).toHaveProperty('metadata');
+      expect(schema!.properties).toHaveProperty('spec');
+      expect(schema!.required).toContain('metadata');
+      expect(schema!.required).toContain('spec');
+    });
+
+    it('should generate metadata schema with standard fields', () => {
+      const schema = generateSchemaForResourceType('http_loadbalancer');
+
+      expect(schema).not.toBeNull();
+      const metadata = schema!.properties.metadata as {
+        type: string;
+        properties: Record<string, unknown>;
+      };
+      expect(metadata).toBeDefined();
+      expect(metadata.type).toBe('object');
+      expect(metadata.properties).toBeDefined();
+      expect(metadata.properties).toHaveProperty('name');
+      expect(metadata.properties).toHaveProperty('namespace');
+      expect(metadata.properties).toHaveProperty('labels');
+      expect(metadata.properties).toHaveProperty('annotations');
+      expect(metadata.properties).toHaveProperty('description');
+      expect(metadata.properties).toHaveProperty('disable');
+    });
+
+    it('should mark metadata.name as required', () => {
+      const schema = generateSchemaForResourceType('http_loadbalancer');
+
+      expect(schema).not.toBeNull();
+      const metadata = schema!.properties.metadata as {
+        required: string[];
+        properties: Record<string, Record<string, unknown>>;
+      };
+      expect(metadata).toBeDefined();
+      expect(metadata.required).toContain('name');
+      expect(metadata.properties).toBeDefined();
+      const nameField = metadata.properties['name']!;
+      expect(nameField).toBeDefined();
+      expect(nameField['x-f5xc-required']).toBe(true);
+    });
+
+    it('should return null for unknown resource type', () => {
+      const schema = generateSchemaForResourceType('unknown_resource_type');
+
+      expect(schema).toBeNull();
+    });
+
+    it('should generate schema for healthcheck with field metadata', () => {
+      const schema = generateSchemaForResourceType('healthcheck');
+
+      expect(schema).not.toBeNull();
+      expect(schema!.title).toContain('Health Check');
+      expect(schema!.properties.spec).toBeDefined();
+    });
+
+    it('should include description from resource type', () => {
+      const schema = generateSchemaForResourceType('healthcheck');
+
+      expect(schema).not.toBeNull();
+      expect(schema!.description).toBeDefined();
+      expect(typeof schema!.description).toBe('string');
+      expect(schema!.description!.length).toBeGreaterThan(0);
+    });
+
+    it('should generate schema for origin_pool', () => {
+      const schema = generateSchemaForResourceType('origin_pool');
+
+      expect(schema).not.toBeNull();
+      expect(schema!.$id).toBe('f5xc-schema://schemas/origin_pool.json');
+      expect(schema!.properties.metadata).toBeDefined();
+      expect(schema!.properties.spec).toBeDefined();
+    });
+
+    it('should generate schema for app_firewall', () => {
+      const schema = generateSchemaForResourceType('app_firewall');
+
+      expect(schema).not.toBeNull();
+      expect(schema!.$id).toBe('f5xc-schema://schemas/app_firewall.json');
+    });
+
+    it('should handle resource types without field metadata', () => {
+      // Find a resource type that might not have detailed field metadata
+      const schema = generateSchemaForResourceType('alert_policy');
+
+      // Should still generate a valid schema
+      expect(schema).not.toBeNull();
+      expect(schema!.properties.metadata).toBeDefined();
+      expect(schema!.properties.spec).toBeDefined();
+      // spec should allow additional properties when no field metadata
+      const spec = schema!.properties.spec as { additionalProperties: boolean };
+      expect(spec.additionalProperties).toBe(true);
+    });
+  });
+
+  describe('generateGenericSchema', () => {
+    it('should generate a valid generic schema', () => {
+      const schema = generateGenericSchema();
+
+      expect(schema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+      expect(schema.$id).toBe('f5xc-schema://schemas/generic.json');
+      expect(schema.title).toBe('F5 XC Resource');
+      expect(schema.type).toBe('object');
+    });
+
+    it('should include metadata and spec properties', () => {
+      const schema = generateGenericSchema();
+
+      expect(schema.properties).toHaveProperty('metadata');
+      expect(schema.properties).toHaveProperty('spec');
+      expect(schema.required).toContain('metadata');
+      expect(schema.required).toContain('spec');
+    });
+
+    it('should have flexible spec that allows additional properties', () => {
+      const schema = generateGenericSchema();
+
+      const spec = schema.properties.spec as { additionalProperties: boolean };
+      expect(spec.additionalProperties).toBe(true);
+    });
+
+    it('should have description', () => {
+      const schema = generateGenericSchema();
+
+      expect(schema.description).toBe('Generic schema for F5 Distributed Cloud resources');
+    });
+  });
+
+  describe('getSchemaResourceTypes', () => {
+    it('should return an array of resource type keys', () => {
+      const types = getSchemaResourceTypes();
+
+      expect(Array.isArray(types)).toBe(true);
+      expect(types.length).toBeGreaterThan(0);
+    });
+
+    it('should include common resource types', () => {
+      const types = getSchemaResourceTypes();
+
+      expect(types).toContain('http_loadbalancer');
+      expect(types).toContain('origin_pool');
+      expect(types).toContain('healthcheck');
+      expect(types).toContain('app_firewall');
+    });
+
+    it('should return at least 200 resource types', () => {
+      const types = getSchemaResourceTypes();
+
+      // Based on the generated resource types (234)
+      expect(types.length).toBeGreaterThanOrEqual(200);
+    });
+
+    it('should return unique keys', () => {
+      const types = getSchemaResourceTypes();
+      const uniqueTypes = [...new Set(types)];
+
+      expect(types.length).toBe(uniqueTypes.length);
+    });
+  });
+
+  describe('hasDetailedFieldMetadata', () => {
+    it('should return true for healthcheck which has field metadata', () => {
+      const hasMetadata = hasDetailedFieldMetadata('healthcheck');
+
+      expect(hasMetadata).toBe(true);
+    });
+
+    it('should return true for origin_pool which has field metadata', () => {
+      const hasMetadata = hasDetailedFieldMetadata('origin_pool');
+
+      expect(hasMetadata).toBe(true);
+    });
+
+    it('should return false for unknown resource type', () => {
+      const hasMetadata = hasDetailedFieldMetadata('unknown_resource');
+
+      expect(hasMetadata).toBe(false);
+    });
+
+    it('should return boolean for any valid resource type', () => {
+      const types = getSchemaResourceTypes();
+
+      for (const type of types.slice(0, 10)) {
+        const hasMetadata = hasDetailedFieldMetadata(type);
+        expect(typeof hasMetadata).toBe('boolean');
+      }
+    });
+  });
+
+  describe('Schema structure validation', () => {
+    it('should generate schemas with valid JSON Schema draft-07 structure', () => {
+      const types = ['http_loadbalancer', 'origin_pool', 'healthcheck', 'app_firewall'];
+
+      for (const type of types) {
+        const schema = generateSchemaForResourceType(type);
+        expect(schema).not.toBeNull();
+
+        // Validate required JSON Schema properties
+        expect(schema!.$schema).toBe('http://json-schema.org/draft-07/schema#');
+        expect(schema!.$id).toMatch(/^f5xc-schema:\/\/schemas\/[a-z_]+\.json$/);
+        expect(schema!.type).toBe('object');
+        expect(schema!.properties).toBeDefined();
+        expect(typeof schema!.properties).toBe('object');
+      }
+    });
+
+    it('should have consistent metadata schema across resource types', () => {
+      const schema1 = generateSchemaForResourceType('http_loadbalancer');
+      const schema2 = generateSchemaForResourceType('origin_pool');
+
+      expect(schema1).not.toBeNull();
+      expect(schema2).not.toBeNull();
+
+      // Metadata schemas should be structurally identical
+      const meta1 = schema1!.properties.metadata as { properties?: Record<string, unknown> };
+      const meta2 = schema2!.properties.metadata as { properties?: Record<string, unknown> };
+      const meta1Keys = Object.keys(meta1.properties || {}).sort();
+      const meta2Keys = Object.keys(meta2.properties || {}).sort();
+
+      expect(meta1Keys).toEqual(meta2Keys);
+    });
+  });
+
+  describe('Field metadata integration', () => {
+    it('should include x-f5xc-required extension for required fields', () => {
+      const schema = generateSchemaForResourceType('healthcheck');
+
+      expect(schema).not.toBeNull();
+      // metadata.name should always be marked as required
+      const metadata = schema!.properties.metadata as {
+        properties: Record<string, Record<string, unknown>>;
+      };
+      expect(metadata.properties).toBeDefined();
+      const nameField = metadata.properties['name']!;
+      expect(nameField).toBeDefined();
+      expect(nameField['x-f5xc-required']).toBe(true);
+    });
+
+    it('should include recommended values as defaults when available', () => {
+      const schema = generateSchemaForResourceType('healthcheck');
+
+      expect(schema).not.toBeNull();
+      const spec = schema!.properties.spec as { properties: Record<string, unknown> };
+
+      // healthcheck has recommended values for interval, timeout, etc.
+      // These should appear as defaults in the schema
+      expect(spec.properties).toBeDefined();
+    });
+
+    it('should mark server-defaulted fields with extension', () => {
+      const schema = generateSchemaForResourceType('healthcheck');
+
+      expect(schema).not.toBeNull();
+      // Should have spec properties that include server default markers
+      const spec = schema!.properties.spec as { type: string };
+      expect(spec.type).toBe('object');
+    });
+  });
+
+  describe('Schema generation determinism', () => {
+    it('should produce identical schemas on multiple calls', () => {
+      const schema1 = generateSchemaForResourceType('http_loadbalancer');
+      const schema2 = generateSchemaForResourceType('http_loadbalancer');
+
+      expect(JSON.stringify(schema1)).toBe(JSON.stringify(schema2));
+    });
+
+    it('should produce identical generic schemas on multiple calls', () => {
+      const schema1 = generateGenericSchema();
+      const schema2 = generateGenericSchema();
+
+      expect(JSON.stringify(schema1)).toBe(JSON.stringify(schema2));
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle empty string resource type', () => {
+      const schema = generateSchemaForResourceType('');
+
+      expect(schema).toBeNull();
+    });
+
+    it('should handle resource type with special characters', () => {
+      const schema = generateSchemaForResourceType('invalid/resource');
+
+      expect(schema).toBeNull();
+    });
+
+    it('should not throw for any input', () => {
+      const testInputs = ['', 'unknown', '123', 'a'.repeat(1000), null as unknown as string];
+
+      for (const input of testInputs) {
+        expect(() => generateSchemaForResourceType(input)).not.toThrow();
+      }
+    });
+  });
+});

--- a/src/test/unit/schemaProvider.test.ts
+++ b/src/test/unit/schemaProvider.test.ts
@@ -1,0 +1,368 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Unit tests for the F5 XC Schema Provider
+ */
+
+import { F5XCSchemaProvider, getSchemaUriForDocument } from '../../providers/f5xcSchemaProvider';
+import { resetSchemaRegistry } from '../../schema/schemaRegistry';
+
+// Mock vscode module
+const mockEventEmitter = {
+  event: jest.fn(),
+  fire: jest.fn(),
+  dispose: jest.fn(),
+};
+
+jest.mock(
+  'vscode',
+  () => ({
+    EventEmitter: jest.fn(() => mockEventEmitter),
+    Uri: {
+      parse: jest.fn((uri: string) => ({
+        toString: () => uri,
+        scheme: uri.split(':')[0],
+        path: uri.includes('://') ? uri.split('://')[1] : uri,
+        authority: '',
+      })),
+    },
+    window: {
+      createOutputChannel: jest.fn(() => ({
+        appendLine: jest.fn(),
+        append: jest.fn(),
+        show: jest.fn(),
+        hide: jest.fn(),
+        dispose: jest.fn(),
+        clear: jest.fn(),
+        replace: jest.fn(),
+        name: 'F5 XC',
+      })),
+    },
+    workspace: {
+      getConfiguration: jest.fn(() => ({
+        get: jest.fn(() => ({})),
+      })),
+    },
+  }),
+  { virtual: true },
+);
+
+describe('F5XCSchemaProvider', () => {
+  let provider: F5XCSchemaProvider;
+
+  beforeEach(() => {
+    resetSchemaRegistry();
+    provider = new F5XCSchemaProvider();
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should create instance with event emitter', () => {
+      expect(provider).toBeInstanceOf(F5XCSchemaProvider);
+      expect(provider.onDidChange).toBeDefined();
+    });
+  });
+
+  describe('provideTextDocumentContent', () => {
+    it('should return schema content for valid resource type URI', () => {
+      const uri = {
+        path: '/schemas/http_loadbalancer.json',
+        toString: () => 'f5xc-schema://schemas/http_loadbalancer.json',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+
+      expect(typeof content).toBe('string');
+      const parsed = JSON.parse(content);
+      expect(parsed.$id).toContain('http_loadbalancer');
+    });
+
+    it('should return schema content for healthcheck', () => {
+      const uri = {
+        path: '/schemas/healthcheck.json',
+        toString: () => 'f5xc-schema://schemas/healthcheck.json',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+
+      const parsed = JSON.parse(content);
+      expect(parsed.title).toContain('Health Check');
+    });
+
+    it('should return schema content for origin_pool', () => {
+      const uri = {
+        path: '/schemas/origin_pool.json',
+        toString: () => 'f5xc-schema://schemas/origin_pool.json',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+
+      const parsed = JSON.parse(content);
+      expect(parsed.$id).toContain('origin_pool');
+    });
+
+    it('should return generic schema for "generic" resource type', () => {
+      const uri = {
+        path: '/schemas/generic.json',
+        toString: () => 'f5xc-schema://schemas/generic.json',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+
+      const parsed = JSON.parse(content);
+      expect(parsed.title).toBe('F5 XC Resource');
+    });
+
+    it('should return error schema for invalid URI format', () => {
+      const uri = {
+        path: '/invalid/path',
+        toString: () => 'f5xc-schema://invalid/path',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+
+      const parsed = JSON.parse(content);
+      expect(parsed.title).toBe('Error');
+      expect(parsed.description).toContain('Invalid schema URI');
+    });
+
+    it('should handle URI without .json extension', () => {
+      const uri = {
+        path: '/schemas/http_loadbalancer',
+        toString: () => 'f5xc-schema://schemas/http_loadbalancer',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+
+      // Should return error schema since pattern requires .json
+      const parsed = JSON.parse(content);
+      expect(parsed.title).toBe('Error');
+    });
+
+    it('should return generic schema for unknown resource type', () => {
+      const uri = {
+        path: '/schemas/unknown_resource_type.json',
+        toString: () => 'f5xc-schema://schemas/unknown_resource_type.json',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+
+      // Should fall back to generic schema
+      const parsed = JSON.parse(content);
+      expect(parsed.title).toBe('F5 XC Resource');
+    });
+  });
+
+  describe('notifySchemaChanged', () => {
+    it('should fire change event for specified resource type', () => {
+      provider.notifySchemaChanged('http_loadbalancer');
+
+      expect(mockEventEmitter.fire).toHaveBeenCalled();
+    });
+
+    it('should fire change event with correct URI', () => {
+      provider.notifySchemaChanged('origin_pool');
+
+      expect(mockEventEmitter.fire).toHaveBeenCalled();
+    });
+  });
+
+  describe('notifyAllSchemasChanged', () => {
+    it('should fire change events for all resource types', () => {
+      provider.notifyAllSchemasChanged();
+
+      // Should fire multiple times (once for each resource type + generic)
+      expect(mockEventEmitter.fire.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('schema content validation', () => {
+    it('should return valid JSON Schema for all common resource types', () => {
+      const resourceTypes = [
+        'http_loadbalancer',
+        'origin_pool',
+        'healthcheck',
+        'app_firewall',
+        'tcp_loadbalancer',
+        'dns_load_balancer',
+      ];
+
+      for (const resourceType of resourceTypes) {
+        const uri = {
+          path: `/schemas/${resourceType}.json`,
+          toString: () => `f5xc-schema://schemas/${resourceType}.json`,
+        };
+
+        const content = provider.provideTextDocumentContent(uri as any);
+
+        expect(() => JSON.parse(content)).not.toThrow();
+        const parsed = JSON.parse(content);
+        expect(parsed.$schema).toBe('http://json-schema.org/draft-07/schema#');
+        expect(parsed.type).toBe('object');
+        expect(parsed.properties).toBeDefined();
+      }
+    });
+
+    it('should include metadata and spec properties in all schemas', () => {
+      const uri = {
+        path: '/schemas/http_loadbalancer.json',
+        toString: () => 'f5xc-schema://schemas/http_loadbalancer.json',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+      const parsed = JSON.parse(content);
+
+      expect(parsed.properties.metadata).toBeDefined();
+      expect(parsed.properties.spec).toBeDefined();
+      expect(parsed.required).toContain('metadata');
+      expect(parsed.required).toContain('spec');
+    });
+  });
+});
+
+describe('getSchemaUriForDocument', () => {
+  beforeEach(() => {
+    resetSchemaRegistry();
+  });
+
+  it('should return null for non-f5xc scheme', () => {
+    const documentUri = {
+      scheme: 'file',
+      path: '/some/file.json',
+    };
+
+    const result = getSchemaUriForDocument(documentUri as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return schema URI for valid f5xc document URI', () => {
+    const documentUri = {
+      scheme: 'f5xc',
+      path: '/default/http_loadbalancer/my-lb.json',
+    };
+
+    const result = getSchemaUriForDocument(documentUri as any);
+
+    expect(result).not.toBeNull();
+    expect(result!.toString()).toContain('http_loadbalancer');
+  });
+
+  it('should return generic schema URI for unknown resource type', () => {
+    const documentUri = {
+      scheme: 'f5xc',
+      path: '/default/unknown_type/resource.json',
+    };
+
+    const result = getSchemaUriForDocument(documentUri as any);
+
+    expect(result).not.toBeNull();
+    expect(result!.toString()).toContain('generic');
+  });
+
+  it('should return null for invalid path format', () => {
+    const documentUri = {
+      scheme: 'f5xc',
+      path: '/invalid',
+    };
+
+    const result = getSchemaUriForDocument(documentUri as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for empty path', () => {
+    const documentUri = {
+      scheme: 'f5xc',
+      path: '',
+    };
+
+    const result = getSchemaUriForDocument(documentUri as any);
+
+    expect(result).toBeNull();
+  });
+
+  it('should extract resource type correctly from various paths', () => {
+    const testCases = [
+      { path: '/namespace/http_loadbalancer/lb.json', expectedType: 'http_loadbalancer' },
+      { path: '/default/origin_pool/pool.json', expectedType: 'origin_pool' },
+      { path: '/shared/healthcheck/hc.json', expectedType: 'healthcheck' },
+    ];
+
+    for (const { path, expectedType } of testCases) {
+      const documentUri = {
+        scheme: 'f5xc',
+        path,
+      };
+
+      const result = getSchemaUriForDocument(documentUri as any);
+
+      expect(result).not.toBeNull();
+      expect(result!.toString()).toContain(expectedType);
+    }
+  });
+});
+
+describe('Schema Provider Integration', () => {
+  let provider: F5XCSchemaProvider;
+
+  beforeEach(() => {
+    resetSchemaRegistry();
+    provider = new F5XCSchemaProvider();
+  });
+
+  describe('consistency between calls', () => {
+    it('should return identical content for same URI', () => {
+      const uri = {
+        path: '/schemas/http_loadbalancer.json',
+        toString: () => 'f5xc-schema://schemas/http_loadbalancer.json',
+      };
+
+      const content1 = provider.provideTextDocumentContent(uri as any);
+      const content2 = provider.provideTextDocumentContent(uri as any);
+
+      expect(content1).toBe(content2);
+    });
+
+    it('should return different content for different resource types', () => {
+      const uri1 = {
+        path: '/schemas/http_loadbalancer.json',
+        toString: () => 'f5xc-schema://schemas/http_loadbalancer.json',
+      };
+      const uri2 = {
+        path: '/schemas/origin_pool.json',
+        toString: () => 'f5xc-schema://schemas/origin_pool.json',
+      };
+
+      const content1 = provider.provideTextDocumentContent(uri1 as any);
+      const content2 = provider.provideTextDocumentContent(uri2 as any);
+
+      expect(content1).not.toBe(content2);
+
+      const parsed1 = JSON.parse(content1);
+      const parsed2 = JSON.parse(content2);
+      expect(parsed1.$id).not.toBe(parsed2.$id);
+    });
+  });
+
+  describe('schema content structure', () => {
+    it('should provide schemas usable by JSON language service', () => {
+      const uri = {
+        path: '/schemas/healthcheck.json',
+        toString: () => 'f5xc-schema://schemas/healthcheck.json',
+      };
+
+      const content = provider.provideTextDocumentContent(uri as any);
+      const schema = JSON.parse(content);
+
+      // Required properties for JSON language service
+      expect(schema.$schema).toBeDefined();
+      expect(schema.type).toBeDefined();
+      expect(schema.properties).toBeDefined();
+
+      // Metadata should have name property
+      expect(schema.properties.metadata.properties.name).toBeDefined();
+      expect(schema.properties.metadata.properties.name.type).toBe('string');
+    });
+  });
+});

--- a/src/test/unit/schemaRegistry.test.ts
+++ b/src/test/unit/schemaRegistry.test.ts
@@ -1,0 +1,330 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Unit tests for the Schema Registry
+ */
+
+import {
+  SchemaRegistry,
+  getSchemaRegistry,
+  resetSchemaRegistry,
+} from '../../schema/schemaRegistry';
+
+// Mock vscode module
+jest.mock(
+  'vscode',
+  () => ({
+    Uri: {
+      parse: jest.fn((uri: string) => ({ toString: () => uri, scheme: uri.split(':')[0] })),
+    },
+    window: {
+      createOutputChannel: jest.fn(() => ({
+        appendLine: jest.fn(),
+        append: jest.fn(),
+        show: jest.fn(),
+        hide: jest.fn(),
+        dispose: jest.fn(),
+        clear: jest.fn(),
+        replace: jest.fn(),
+        name: 'F5 XC',
+      })),
+    },
+    workspace: {
+      getConfiguration: jest.fn(() => ({
+        get: jest.fn(() => ({})),
+      })),
+    },
+  }),
+  { virtual: true },
+);
+
+describe('Schema Registry', () => {
+  let registry: SchemaRegistry;
+
+  beforeEach(() => {
+    // Reset singleton and create fresh instance for each test
+    resetSchemaRegistry();
+    registry = new SchemaRegistry();
+  });
+
+  describe('constructor', () => {
+    it('should create a new instance', () => {
+      expect(registry).toBeInstanceOf(SchemaRegistry);
+    });
+
+    it('should start with empty cache', () => {
+      const stats = registry.getCacheStats();
+      expect(stats.cachedCount).toBe(0);
+    });
+  });
+
+  describe('getSchemaUri', () => {
+    it('should return URI for resource type', () => {
+      const uri = registry.getSchemaUri('http_loadbalancer');
+
+      expect(uri.toString()).toBe('f5xc-schema://schemas/http_loadbalancer.json');
+    });
+
+    it('should return URI for any resource type string', () => {
+      const uri = registry.getSchemaUri('custom_type');
+
+      expect(uri.toString()).toBe('f5xc-schema://schemas/custom_type.json');
+    });
+  });
+
+  describe('getGenericSchemaUri', () => {
+    it('should return generic schema URI', () => {
+      const uri = registry.getGenericSchemaUri();
+
+      expect(uri.toString()).toBe('f5xc-schema://schemas/generic.json');
+    });
+  });
+
+  describe('getOrGenerateSchema', () => {
+    it('should generate schema for valid resource type', () => {
+      const schema = registry.getOrGenerateSchema('http_loadbalancer');
+
+      expect(schema).not.toBeNull();
+      expect(schema!.$id).toContain('http_loadbalancer');
+    });
+
+    it('should cache schema after first generation', () => {
+      const schema1 = registry.getOrGenerateSchema('http_loadbalancer');
+      const schema2 = registry.getOrGenerateSchema('http_loadbalancer');
+
+      expect(schema1).toBe(schema2); // Same reference (cached)
+    });
+
+    it('should return null for unknown resource type', () => {
+      const schema = registry.getOrGenerateSchema('unknown_resource');
+
+      expect(schema).toBeNull();
+    });
+
+    it('should increment cached count after generation', () => {
+      expect(registry.getCacheStats().cachedCount).toBe(0);
+
+      registry.getOrGenerateSchema('http_loadbalancer');
+      expect(registry.getCacheStats().cachedCount).toBe(1);
+
+      registry.getOrGenerateSchema('origin_pool');
+      expect(registry.getCacheStats().cachedCount).toBe(2);
+    });
+
+    it('should not increment cached count for same resource type', () => {
+      registry.getOrGenerateSchema('http_loadbalancer');
+      registry.getOrGenerateSchema('http_loadbalancer');
+      registry.getOrGenerateSchema('http_loadbalancer');
+
+      expect(registry.getCacheStats().cachedCount).toBe(1);
+    });
+  });
+
+  describe('getGenericSchema', () => {
+    it('should return generic schema', () => {
+      const schema = registry.getGenericSchema();
+
+      expect(schema).toBeDefined();
+      expect(schema.$id).toContain('generic');
+      expect(schema.title).toBe('F5 XC Resource');
+    });
+
+    it('should cache generic schema', () => {
+      const schema1 = registry.getGenericSchema();
+      const schema2 = registry.getGenericSchema();
+
+      expect(schema1).toBe(schema2); // Same reference (cached)
+    });
+  });
+
+  describe('getSchemaContent', () => {
+    it('should return JSON string for valid resource type', () => {
+      const content = registry.getSchemaContent('http_loadbalancer');
+
+      expect(typeof content).toBe('string');
+      expect(() => JSON.parse(content)).not.toThrow();
+    });
+
+    it('should return generic schema content for "generic"', () => {
+      const content = registry.getSchemaContent('generic');
+
+      const parsed = JSON.parse(content);
+      expect(parsed.title).toBe('F5 XC Resource');
+    });
+
+    it('should return generic schema for unknown resource type', () => {
+      const content = registry.getSchemaContent('unknown_resource');
+
+      const parsed = JSON.parse(content);
+      // Should fall back to generic schema
+      expect(parsed.title).toBe('F5 XC Resource');
+    });
+
+    it('should return properly formatted JSON', () => {
+      const content = registry.getSchemaContent('http_loadbalancer');
+
+      // Should be pretty-printed with 2-space indentation
+      expect(content).toContain('\n');
+      expect(content).toMatch(/^\{\n {2}"/);
+    });
+  });
+
+  describe('getAvailableResourceTypes', () => {
+    it('should return array of resource type keys', () => {
+      const types = registry.getAvailableResourceTypes();
+
+      expect(Array.isArray(types)).toBe(true);
+      expect(types.length).toBeGreaterThan(0);
+    });
+
+    it('should include common resource types', () => {
+      const types = registry.getAvailableResourceTypes();
+
+      expect(types).toContain('http_loadbalancer');
+      expect(types).toContain('origin_pool');
+      expect(types).toContain('healthcheck');
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear all cached schemas', () => {
+      // Populate cache
+      registry.getOrGenerateSchema('http_loadbalancer');
+      registry.getOrGenerateSchema('origin_pool');
+      registry.getGenericSchema();
+
+      expect(registry.getCacheStats().cachedCount).toBe(2);
+
+      // Clear cache
+      registry.clearCache();
+
+      expect(registry.getCacheStats().cachedCount).toBe(0);
+    });
+
+    it('should allow re-generation after clearing', () => {
+      registry.getOrGenerateSchema('http_loadbalancer');
+      registry.clearCache();
+
+      const schema = registry.getOrGenerateSchema('http_loadbalancer');
+      expect(schema).not.toBeNull();
+      expect(registry.getCacheStats().cachedCount).toBe(1);
+    });
+  });
+
+  describe('prewarmCache', () => {
+    it('should populate cache for specified resource types', () => {
+      registry.prewarmCache(['http_loadbalancer', 'origin_pool']);
+
+      expect(registry.getCacheStats().cachedCount).toBe(2);
+    });
+
+    it('should use default resource types when none specified', () => {
+      registry.prewarmCache();
+
+      // Default types: http_loadbalancer, origin_pool, healthcheck, app_firewall
+      expect(registry.getCacheStats().cachedCount).toBe(4);
+    });
+
+    it('should skip invalid resource types without throwing', () => {
+      expect(() => {
+        registry.prewarmCache(['http_loadbalancer', 'invalid_type', 'origin_pool']);
+      }).not.toThrow();
+
+      // Should only cache the valid ones
+      expect(registry.getCacheStats().cachedCount).toBe(2);
+    });
+  });
+
+  describe('hasSchema', () => {
+    it('should return true for cached resource type', () => {
+      registry.getOrGenerateSchema('http_loadbalancer');
+
+      expect(registry.hasSchema('http_loadbalancer')).toBe(true);
+    });
+
+    it('should return true for uncached but valid resource type', () => {
+      expect(registry.hasSchema('http_loadbalancer')).toBe(true);
+    });
+
+    it('should return false for unknown resource type', () => {
+      expect(registry.hasSchema('unknown_resource')).toBe(false);
+    });
+  });
+
+  describe('getCacheStats', () => {
+    it('should return correct cache statistics', () => {
+      const stats = registry.getCacheStats();
+
+      expect(stats).toHaveProperty('cachedCount');
+      expect(stats).toHaveProperty('availableCount');
+      expect(typeof stats.cachedCount).toBe('number');
+      expect(typeof stats.availableCount).toBe('number');
+    });
+
+    it('should update cachedCount as schemas are generated', () => {
+      expect(registry.getCacheStats().cachedCount).toBe(0);
+
+      registry.getOrGenerateSchema('http_loadbalancer');
+      expect(registry.getCacheStats().cachedCount).toBe(1);
+
+      registry.getOrGenerateSchema('origin_pool');
+      expect(registry.getCacheStats().cachedCount).toBe(2);
+    });
+
+    it('should report correct availableCount', () => {
+      const stats = registry.getCacheStats();
+
+      // Should match total number of generated resource types (234+)
+      expect(stats.availableCount).toBeGreaterThanOrEqual(200);
+    });
+  });
+
+  describe('singleton pattern', () => {
+    it('getSchemaRegistry should return same instance', () => {
+      const registry1 = getSchemaRegistry();
+      const registry2 = getSchemaRegistry();
+
+      expect(registry1).toBe(registry2);
+    });
+
+    it('resetSchemaRegistry should create new instance', () => {
+      const registry1 = getSchemaRegistry();
+      registry1.getOrGenerateSchema('http_loadbalancer');
+
+      resetSchemaRegistry();
+
+      const registry2 = getSchemaRegistry();
+      // New instance should have empty cache
+      expect(registry2.getCacheStats().cachedCount).toBe(0);
+    });
+  });
+
+  describe('thread safety and consistency', () => {
+    it('should produce consistent results across multiple calls', () => {
+      const results: string[] = [];
+
+      for (let i = 0; i < 10; i++) {
+        const content = registry.getSchemaContent('http_loadbalancer');
+        results.push(content);
+      }
+
+      // All results should be identical
+      const firstResult = results[0];
+      expect(results.every((r) => r === firstResult)).toBe(true);
+    });
+
+    it('should handle rapid sequential access', () => {
+      const types = ['http_loadbalancer', 'origin_pool', 'healthcheck', 'app_firewall'];
+
+      // Rapidly access schemas
+      for (let i = 0; i < 100; i++) {
+        const type = types[i % types.length];
+        const schema = registry.getOrGenerateSchema(type!);
+        expect(schema).not.toBeNull();
+      }
+
+      // Only 4 unique types should be cached
+      expect(registry.getCacheStats().cachedCount).toBe(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements dynamic JSON schema provider for VSCode IntelliSense support on F5 XC resources. Enables autocomplete, validation, and inline documentation when editing resource files.

## Changes

- **F5XCSchemaProvider**: New TextDocumentContentProvider serving schemas via f5xc-schema:// URI scheme
- **schemaRegistry**: Caching layer with pre-warm capability for common resource types
- **schemaGenerator**: Generates JSON schemas from F5 XC API specifications
- **package.json**: Updated jsonValidation entries to use dynamic schema URIs
- **extension.ts**: Registered schema provider, added language mode handling for f5xc:// documents
- **Unit tests**: Coverage for schema generation, registry, and provider functionality

## Resource Support

- http_loadbalancer
- origin_pool
- healthcheck (NEW)
- app_firewall
- tcp_loadbalancer (NEW)
- dns_load_balancer (NEW)
- virtual_site (NEW)
- Generic fallback for other types

Closes #103