### PR TITLE
fix: add cspsource to healthcheck form csp to allow toolkit loading

### DIFF
--- a/src/providers/healthcheckFormProvider.ts
+++ b/src/providers/healthcheckFormProvider.ts
@@ -482,13 +482,14 @@ export class HealthcheckFormProvider {
     const nonce = this.getNonce();
     const toolkitUri = this.getToolkitUri();
     const quotaExceeded = quotaInfo ? quotaInfo.usage >= quotaInfo.limit : false;
+    const cspSource = this.panel!.webview.cspSource;
 
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}' ${cspSource};">
   <script type="module" nonce="${nonce}" src="${toolkitUri.toString()}"></script>
   <style>
     ${this.getStyles()}


### PR DESCRIPTION
## Summary
- Fixed Content-Security-Policy in healthcheck form webview to allow the VSCode Webview UI Toolkit to load
- Added `cspSource` to both `style-src` and `script-src` CSP directives

## Problem
The healthcheck creation form was not rendering because the CSP blocked the toolkit JavaScript from loading. Without the toolkit, the custom elements (`<vscode-text-field>`, `<vscode-button>`, etc.) remained as unrecognized HTML elements with no functionality.

## Test plan
- [ ] Open F5 XC Explorer
- [ ] Navigate to namespace → Networking → Healthchecks  
- [ ] Click the + icon on Healthchecks
- [ ] Verify the "Create Healthcheck" form renders with all input fields
- [ ] Verify form submission creates a healthcheck

Fixes #105

🤖 Generated with [Claude Code](https://claude.ai/code)