### PR TITLE
feat: migrate healthcheck form toolkit to cdn delivery

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -237,7 +237,6 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // Register healthcheck form provider
   const healthcheckFormProvider = new HealthcheckFormProvider(
-    context,
     profileManager,
     explorerProvider,
     describeProvider,


### PR DESCRIPTION
## Summary

Remove local bundling of VS Code Webview UI Toolkit and load it directly from CDN (jsDelivr) instead.

## Changes
- Remove context.extensionUri dependency from HealthcheckFormProvider
- Remove localResourceRoots requirement for node_modules
- Load toolkit components via ES module import from CDN
- Update CSP to allow cdn.jsdelivr.net for script loading
- Initialize toolkit with provideVSCodeDesignSystem()

## Benefits
- Reduce extension bundle size
- Simplify dependency management
- Ensure compatibility with webview security policies
- Reduce build complexity

Closes #115