### PR TITLE
ci: Add Dependabot Auto-Merge Configuration (Aggressive)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration for automated dependency updates
+# Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    reviewers:
+      - "robinmordasiewicz"
+    # Auto-merge strategy (controlled by workflow)
+    allow:
+      - dependency-type: "all"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "robinmordasiewicz"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,61 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-Merge Dependabot PRs
+    runs-on: ubuntu-latest
+
+    # Only run for Dependabot PRs
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Check update type
+        id: check-update
+        run: |
+          # AGGRESSIVE MODE: Auto-merge ALL dependency updates
+          UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
+
+          echo "should_merge=true" >> $GITHUB_OUTPUT
+          echo "✅ Auto-merge approved for all updates: $UPDATE_TYPE"
+          echo "📦 Dependency: ${{ steps.metadata.outputs.dependency-names }}"
+          echo "🔄 Update: ${{ steps.metadata.outputs.previous-version }} → ${{ steps.metadata.outputs.new-version }}"
+
+      - name: Approve PR
+        if: steps.check-update.outputs.should_merge == 'true'
+        run: |
+          gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.check-update.outputs.should_merge == 'true'
+        run: |
+          # Enable auto-merge to merge when all checks pass
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log auto-merge action
+        if: steps.check-update.outputs.should_merge == 'true'
+        run: |
+          echo "🤖 Auto-merge enabled for Dependabot PR"
+          echo "  Dependency: ${{ steps.metadata.outputs.dependency-names }}"
+          echo "  Update Type: ${{ steps.metadata.outputs.update-type }}"
+          echo "  Version: ${{ steps.metadata.outputs.previous-version }} → ${{ steps.metadata.outputs.new-version }}"
+          echo "  Will merge when CI passes ✅"


### PR DESCRIPTION
## Overview
Add Dependabot configuration with aggressive auto-merge for ALL dependency updates.

## Changes
- ✅ Add `.github/dependabot.yml` configuration
- ✅ Add `.github/workflows/dependabot-auto-merge.yml` workflow
- ✅ Configure **daily updates** (2 AM UTC)
- ✅ **Auto-merge ALL updates** (patch, minor, AND major) when CI passes
- ✅ Comprehensive CI suite provides safety net

## Configuration
- **npm dependencies**: Daily updates, max 10 open PRs
- **GitHub Actions**: Daily updates, max 5 open PRs
- **Auto-merge scope**: ALL dependency updates (aggressive mode)
- **Safety**: Requires all CI checks to pass (496 tests, 3 platforms)

## Rationale for Aggressive Approach
- **Comprehensive CI**: 496 unit tests across Ubuntu, macOS, Windows
- **Security Audit**: Runs on every PR
- **Fast Iteration**: Daily updates = smaller, easier-to-debug changes
- **Quick Revert**: Can roll back problematic merges easily
- **Faster Security Patches**: Daily updates minimize vulnerability exposure

## Testing
After merge, Dependabot will:
1. Create PRs for outdated dependencies (daily at 2 AM UTC)
2. Auto-merge workflow will trigger on PR creation
3. **ALL updates** auto-merge when CI passes
4. Monitor for any issues and adjust if needed

## Monitoring Plan
First week after merge:
- Monitor PRs created at 2 AM UTC daily
- Verify auto-merge workflow execution
- Check CI status on auto-merged PRs
- Watch for failed builds or broken functionality
- Can roll back to conservative mode if needed